### PR TITLE
Add support for container secrets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apk add --no-cache nginx shadow \
 
 # Django app
 COPY src ./
-RUN python manage.py collectstatic --noinput
+RUN SECRET="" python manage.py collectstatic --noinput
 
 EXPOSE 8000
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -297,41 +297,72 @@ IMG_NONE = "https://www.themoviedb.org/assets/2/v4/glyphicons/basic/glyphicons-b
 REQUEST_TIMEOUT = 120  # seconds
 PER_PAGE = 24
 
-TMDB_API = config("TMDB_API", default="61572be02f0a068658828f6396aacf60")
+TMDB_API = config(
+    "TMDB_API", default=secret(
+        "TMDB_API_FILE", "61572be02f0a068658828f6396aacf60",
+    ),
+)
 TMDB_NSFW = config("TMDB_NSFW", default=False, cast=bool)
 TMDB_LANG = config("TMDB_LANG", default="en")
 
-MAL_API = config("MAL_API", default="25b5581dafd15b3e7d583bb79e9a1691")
+MAL_API = config(
+    "MAL_API", default=secret(
+        "MAL_API_FILE", "25b5581dafd15b3e7d583bb79e9a1691",
+    ),
+)
 MAL_NSFW = config("MAL_NSFW", default=False, cast=bool)
 
 MU_NSFW = config("MU_NSFW", default=False, cast=bool)
 
-IGDB_ID = config("IGDB_ID", default="8wqmm7x1n2xxtnz94lb8mthadhtgrt")
-IGDB_SECRET = config("IGDB_SECRET", default="ovbq0hwscv58hu46yxn50hovt4j8kj")
+IGDB_ID = config(
+    "IGDB_ID", default=secret(
+        "IGDB_ID_FILE", "8wqmm7x1n2xxtnz94lb8mthadhtgrt",
+    ),
+)
+IGDB_SECRET = config(
+    "IGDB_SECRET", default=secret(
+        "IGDB_SECRET_FILE", "ovbq0hwscv58hu46yxn50hovt4j8kj",
+    ),
+)
 IGDB_NSFW = config("IGDB_NSFW", default=False, cast=bool)
 
 HARDCOVER_API = config(
-    "HARDCOVER_API",
-    default="Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJIYXJkY292ZXIiLCJ2ZXJzaW9uIjoiOCIsImp0aSI6ImJhNGNjZmUwLTgwZmQtNGI3NC1hZDdhLTlkNDM5ZTA5YWMzOSIsImFwcGxpY2F0aW9uSWQiOjIsInN1YiI6IjM0OTUxIiwiYXVkIjoiMSIsImlkIjoiMzQ5NTEiLCJsb2dnZWRJbiI6dHJ1ZSwiaWF0IjoxNzQ2OTc3ODc3LCJleHAiOjE3Nzg1MTM4NzcsImh0dHBzOi8vaGFzdXJhLmlvL2p3dC9jbGFpbXMiOnsieC1oYXN1cmEtYWxsb3dlZC1yb2xlcyI6WyJ1c2VyIl0sIngtaGFzdXJhLWRlZmF1bHQtcm9sZSI6InVzZXIiLCJ4LWhhc3VyYS1yb2xlIjoidXNlciIsIlgtaGFzdXJhLXVzZXItaWQiOiIzNDk1MSJ9LCJ1c2VyIjp7ImlkIjozNDk1MX19.edcEqLAeO3uH5xxBTFDKtyWwi-B-WfXX_yiLFdOAJ3c",  # noqa: E501
+    "HARDCOVER_API", default=secret(
+        "HARDCOVER_API_FILE",
+        "Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJIYXJkY292ZXIiLCJ2ZXJzaW9uIjoiOCIsImp0"
+        "aSI6ImJhNGNjZmUwLTgwZmQtNGI3NC1hZDdhLTlkNDM5ZTA5YWMzOSIsImFwcGxpY2F0aW9uSWQi"
+        "OjIsInN1YiI6IjM0OTUxIiwiYXVkIjoiMSIsImlkIjoiMzQ5NTEiLCJsb2dnZWRJbiI6dHJ1ZSwi"
+        "aWF0IjoxNzQ2OTc3ODc3LCJleHAiOjE3Nzg1MTM4NzcsImh0dHBzOi8vaGFzdXJhLmlvL2p3dC9j"
+        "bGFpbXMiOnsieC1oYXN1cmEtYWxsb3dlZC1yb2xlcyI6WyJ1c2VyIl0sIngtaGFzdXJhLWRlZmF1"
+        "bHQtcm9sZSI6InVzZXIiLCJ4LWhhc3VyYS1yb2xlIjoidXNlciIsIlgtaGFzdXJhLXVzZXItaWQi"
+        "OiIzNDk1MSJ9LCJ1c2VyIjp7ImlkIjozNDk1MX19.edcEqLAeO3uH5xxBTFDKtyWwi-B-WfXX_yi"
+        "LFdOAJ3c",
+    ),
 )
 
 COMICVINE_API = config(
-    "COMICVINE_API",
-    default="cdab0706269e4bca03a096fbc39920dadf7e4992",
+    "COMICVINE_API", default=secret(
+        "COMICVINE_API_FILE", "cdab0706269e4bca03a096fbc39920dadf7e4992",
+    ),
 )
-
 
 TRAKT_API = config(
-    "TRAKT_API",
-    default="b4d9702b11cfaddf5e863001f68ce9d4394b678926e8a3f64d47bf69a55dd0fe",
+    "TRAKT_API", default=secret(
+        "TRAKT_API_FILE",
+        "b4d9702b11cfaddf5e863001f68ce9d4394b678926e8a3f64d47bf69a55dd0fe",
+    ),
 )
 SIMKL_ID = config(
-    "SIMKL_ID",
-    default="f1df351ddbace7e2c52f0010efdeb1fd59d379d9cdfb88e9a847c68af410db0e",
+    "SIMKL_ID", default=secret(
+        "SIMKL_ID_FILE",
+        "f1df351ddbace7e2c52f0010efdeb1fd59d379d9cdfb88e9a847c68af410db0e",
+    ),
 )
 SIMKL_SECRET = config(
-    "SIMKL_SECRET",
-    default="9bb254894a598894bee14f61eafdcdca47622ab346632f951ed7220a3de289b5",
+    "SIMKL_SECRET", default=secret(
+        "SIMKL_SECRET_FILE",
+        "9bb254894a598894bee14f61eafdcdca47622ab346632f951ed7220a3de289b5",
+    ),
 )
 
 TESTING = False


### PR DESCRIPTION
Please see #509.

Added the possibility to specify API keys as secrets too.

When running `python manage.py collectstatic --noinput` in the image build, the `SECRET` variable must be specified since the previous static default "secret" is gone now. This could obviously also use build `ARG` or `ENV`, but currently I don't see the need to provide an actual value. (The secret is not used when collecting static files).

Also fixed some ruff checks related to line length.