### PR TITLE
Configure SESSION and CSRF cookie for subpath

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -88,6 +88,9 @@ for url in URLS:
     CSRF_TRUSTED_ORIGINS.append(url)
     ALLOWED_HOSTS.append(urlparse(url).hostname)
 
+if BASE_URL:
+    CSRF_COOKIE_PATH = BASE_URL + '/'
+
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # Application definition
@@ -510,6 +513,7 @@ ACCOUNT_FORMS = {
 
 if BASE_URL:
     ACCOUNT_LOGOUT_REDIRECT_URL = f"{BASE_URL}/accounts/login/?loggedout=1"
+    SESSION_COOKIE_PATH = BASE_URL + '/'
 
 SOCIALACCOUNT_LOGIN_ON_GET = True
 


### PR DESCRIPTION
Follow up on https://github.com/FuzzyGrim/Yamtrack/pull/548

I think it would be a good idea to configure cookies in subpath if subpath is configured. 