### PR TITLE
Issue #629: Don't stop yamtrack import on error

### DIFF
--- a/src/integrations/imports/yamtrack.py
+++ b/src/integrations/imports/yamtrack.py
@@ -66,8 +66,10 @@ class YamtrackImporter:
             try:
                 self._process_row(row)
             except Exception as error:
-                error_msg = f"Error processing entry: {row}"
-                raise MediaImportUnexpectedError(error_msg) from error
+                error_msg = f"Error processing entry: {row.get('title', 'Unknown')} ({row.get('media_type', 'Unknown')}): {error}"
+                self.warnings.append(error_msg)
+                logger.error(error_msg, exc_info=True)
+                continue
 
         helpers.cleanup_existing_media(self.to_delete, self.user)
         helpers.bulk_create_media(self.bulk_media, self.user)


### PR DESCRIPTION
A fix for issue #629 
For full transparency: This was generated with the help of Claude Sonnet, I'm not a python developer.