### PR TITLE
Make logout redirect URL configurable through environment variable

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -4,7 +4,7 @@ import json
 import warnings
 import zoneinfo
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 from celery.schedules import crontab
 from decouple import (
@@ -503,7 +503,9 @@ else:
     # Empty CSRF_TRUSTED_ORIGINS, default to http
     ACCOUNT_DEFAULT_HTTP_PROTOCOL = "http"
 
-ACCOUNT_LOGOUT_REDIRECT_URL = "/accounts/login/?loggedout=1"
+ACCOUNT_LOGOUT_REDIRECT_URL = config(
+    "ACCOUNT_LOGOUT_REDIRECT_URL", default="/accounts/login/?loggedout=1"
+)
 ACCOUNT_SESSION_REMEMBER = True
 ACCOUNT_USER_MODEL_EMAIL_FIELD = None
 ACCOUNT_FORMS = {
@@ -512,7 +514,9 @@ ACCOUNT_FORMS = {
 }
 
 if BASE_URL:
-    ACCOUNT_LOGOUT_REDIRECT_URL = f"{BASE_URL}/accounts/login/?loggedout=1"
+    # Join base only if relative URL
+    if not urlparse(ACCOUNT_LOGOUT_REDIRECT_URL).netloc:
+        ACCOUNT_LOGOUT_REDIRECT_URL = urljoin(BASE_URL, ACCOUNT_LOGOUT_REDIRECT_URL)
     SESSION_COOKIE_PATH = BASE_URL + "/"
 
 SOCIALACCOUNT_LOGIN_ON_GET = True

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -504,7 +504,7 @@ else:
     ACCOUNT_DEFAULT_HTTP_PROTOCOL = "http"
 
 ACCOUNT_LOGOUT_REDIRECT_URL = config(
-    "ACCOUNT_LOGOUT_REDIRECT_URL", default="/accounts/login/?loggedout=1"
+    "ACCOUNT_LOGOUT_REDIRECT_URL", default="/accounts/login/?loggedout=1",
 )
 ACCOUNT_SESSION_REMEMBER = True
 ACCOUNT_USER_MODEL_EMAIL_FIELD = None


### PR DESCRIPTION
Currently, when using OpenID-Connect for authentication, logging out does not redirect to the authentication provider. Hence, the user is not actually logged out. On page reload the user is directly logged in again as the cookie still exists.
In some cases this might be desired behaviour, but I assume more often than not it is expected to log out the user at the external auth provider. This can be easily achieved though by manually setting the `ACCOUNT_LOGOUT_REDIRECT_URL` value to the absolute URL of the auth provider logout endpoint. Example for Keycloak:
```
https://oauth.internal/realms/master/protocol/openid-connect/logout?post_logout_redirect_uri=/accounts/login/?loggedout=1&client_id=yam.internal
```
Ideally, django-allauth would parse and use this endpoint automatically from the OpenID discovery endpoint, but this doesn't seem to be implemented right now. see https://codeberg.org/allauth/django-allauth/issues/3104