### PR TITLE
implement a rest-endpoint for medialist

### DIFF
--- a/src/integrations/tests/test_api.py
+++ b/src/integrations/tests/test_api.py
@@ -1,0 +1,179 @@
+import json
+from datetime import UTC, datetime
+from urllib.parse import urlencode
+
+from django.contrib.auth import get_user_model
+from django.db.models import Q
+from django.test import TestCase
+from django.urls import reverse
+
+from app import providers
+from app.models import (
+    Book,
+    Episode,
+    Item,
+    MediaTypes,
+    Movie,
+    Season,
+    Sources,
+    Status,
+)
+
+class APITest(TestCase):
+    """Test getting items from the api."""
+
+    def setUp(self):
+        """Create necessary data for the tests."""
+        self.credentials = {"username": "test", "password": "12345", "token": "test-token"}
+        self.user = get_user_model().objects.create_superuser(**self.credentials)
+        self.client.login(**self.credentials)
+
+        item_movie = Item.objects.create(
+            media_id="10494",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.MOVIE.value,
+            title="Perfect Blue",
+            image="https://image.url",
+        )
+        Movie.objects.create(
+            item=item_movie,
+            user=self.user,
+            score=9,
+            status=Status.COMPLETED.value,
+            notes="Nice",
+            start_date=datetime(2023, 6, 1, 0, 0, tzinfo=UTC),
+            end_date=datetime(2023, 6, 1, 0, 0, tzinfo=UTC),
+        )
+
+        item_season = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            title="Friends",
+            image="https://image.url",
+            season_number=1,
+        )
+
+        season = Season.objects.create(
+            item=item_season,
+            user=self.user,
+            score=9,
+            status=Status.IN_PROGRESS.value,
+            notes="Nice",
+        )
+
+        item_episode = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            title="Friends",
+            image="https://image.url",
+            season_number=1,
+            episode_number=1,
+        )
+        Episode.objects.create(
+            item=item_episode,
+            related_season=season,
+            end_date=datetime(2023, 6, 1, 0, 0, tzinfo=UTC),
+        )
+
+        item_book = Item.objects.create(
+            media_id="OL21733390M",
+            source=Sources.OPENLIBRARY.value,
+            media_type=MediaTypes.BOOK.value,
+            title="Fantastic Mr. Fox",
+            image="https://image.url",
+        )
+        Book.objects.create(
+            item=item_book,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+            progress=120,
+            start_date=datetime(2021, 6, 1, 0, 0, tzinfo=UTC),
+        )
+
+    def test_invalid_token(self):
+        """Test api with invalid token returns 401."""
+        url = reverse("api_medialist", kwargs={"media_type": "tv"})
+        query_kwargs = {"token": "invalid-token"}
+        response = self.client.get(f'{url}?{urlencode(query_kwargs)}')
+        self.assertEqual(response.status_code, 401)
+
+    def test_api_medialist_tv(self):
+        """Test receiving basic TV medialist info."""
+        # Generate the CSV file by accessing the export view
+        api_url = reverse("api_medialist", kwargs={"media_type": "tv"})
+        query_kwargs = {"token": "test-token"}
+        response = self.client.get(f'{api_url}?{urlencode(query_kwargs)}')
+
+        # Assert that the response is successful (status code 200)
+        self.assertEqual(response.status_code, 200)
+
+        # Assert that the response content type is text/csv
+        self.assertEqual(response["Content-Type"], "application/json")
+
+        # Read the streaming content and decode it
+        content = [x["tvdbId"] for x in response.json()]
+
+        db_media_ids = set(
+            Item.objects.filter(
+                Q(tv__user=self.user)
+                | Q(season__user=self.user)
+            ).values_list("media_id", flat=True),
+        )
+        for id in db_media_ids:
+            metadata = providers.services.get_media_metadata(
+                    "tv",
+                    id,
+                    Sources.TMDB.value,
+                )
+
+            self.assertTrue(str(metadata["tvdb_id"]) in content)
+
+    def test_api_medialist_movie(self):
+        """Test receiving basic movie medialist info."""
+        # Generate the CSV file by accessing the export view
+        api_url = reverse("api_medialist", kwargs={"media_type": "movie"})
+        query_kwargs = {"token": "test-token"}
+        response = self.client.get(f'{api_url}?{urlencode(query_kwargs)}')
+
+        # Assert that the response is successful (status code 200)
+        self.assertEqual(response.status_code, 200)
+
+        # Assert that the response content type is text/csv
+        self.assertEqual(response["Content-Type"], "application/json")
+
+        # Read the streaming content and decode it
+        content = [x["id"] for x in response.json()]
+
+        db_media_ids = set(
+            Item.objects.filter(
+                Q(movie__user=self.user)
+            ).values_list("media_id", flat=True),
+        )
+        for id in db_media_ids:
+            self.assertTrue(id in content)
+
+    def test_api_medialist_book(self):
+        """Test receiving basic book medialist info."""
+        # Generate the CSV file by accessing the export view
+        api_url = reverse("api_medialist", kwargs={"media_type": "book"})
+        query_kwargs = {"token": "test-token"}
+        response = self.client.get(f'{api_url}?{urlencode(query_kwargs)}')
+
+        # Assert that the response is successful (status code 200)
+        self.assertEqual(response.status_code, 200)
+
+        # Assert that the response content type is text/csv
+        self.assertEqual(response["Content-Type"], "application/json")
+
+        # Read the streaming content and decode it
+        content = [x["id"] for x in response.json()]
+
+        db_media_ids = set(
+            Item.objects.filter(
+                Q(book__user=self.user)
+            ).values_list("media_id", flat=True),
+        )
+        for id in db_media_ids:
+            self.assertTrue(id in content)

--- a/src/integrations/urls.py
+++ b/src/integrations/urls.py
@@ -34,6 +34,6 @@ urlpatterns = [
     path(
         "api/medialist/<media_type:media_type>",
         views.api_medialist,
-        name="api_medialist"
-    )
+        name="api_medialist",
+    ),
 ]

--- a/src/integrations/urls.py
+++ b/src/integrations/urls.py
@@ -31,4 +31,9 @@ urlpatterns = [
         views.emby_webhook,
         name="emby_webhook",
     ),
+    path(
+        "api/medialist/<media_type:media_type>",
+        views.api_medialist,
+        name="api_medialist"
+    )
 ]

--- a/src/integrations/views.py
+++ b/src/integrations/views.py
@@ -8,16 +8,16 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_not_required
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.paginator import Paginator
-from django.http import HttpResponse, StreamingHttpResponse, JsonResponse
+from django.http import HttpResponse, JsonResponse, StreamingHttpResponse
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_POST
 
-from app import providers
-from app.models import BasicMedia, MediaTypes
 import users
+from app import providers
+from app.models import BasicMedia
 from integrations import exports, tasks
 from integrations.imports import helpers, simkl, trakt
 from integrations.webhooks import emby, jellyfin, plex
@@ -366,17 +366,33 @@ def api_medialist(request, media_type):
 
     resp = []
 
-    for object in media_page.object_list:
-        if media_type in [MediaTypes.TV.value, MediaTypes.ANIME.value]:
-            metadata = providers.services.get_media_metadata(
-                    media_type,
-                    object.item.media_id,
-                    object.item.source,
-                )
-            if "tvdb_id" in metadata:
-                resp.append({"tvdbId": str(metadata["tvdb_id"]), "title": str(object.item)})
-        else:
-            resp.append({"id": object.item.media_id, "title": str(object.item)})
+    for media_object in media_page.object_list:
+        item = {
+            "id": media_object.item.media_id,
+            "title": str(media_object.item),
+            "source": media_object.item.source,
+            "tvdbId": None,
+        }
+        m = providers.services.get_media_metadata(
+            media_type,
+            media_object.item.media_id,
+            media_object.item.source,
+        )
+        item.update(
+            {
+                "max_progress": m["max_progress"],
+                "source_url": m["source_url"],
+                "image": m["image"],
+                "synopsis": m["synopsis"],
+                "details": m["details"],
+                "genres": m["genres"],
+                "score": m["score"],
+                "score_count": m["score_count"],
+            },
+        )
+        if "tvdb_id" in m:
+            item["tvdbId"] = str(m["tvdb_id"])
+        resp.append(item)
 
     return JsonResponse(
         resp,

--- a/src/integrations/views.py
+++ b/src/integrations/views.py
@@ -367,19 +367,17 @@ def api_medialist(request, media_type):
     resp = []
 
     for media_object in media_page.object_list:
-        item = {
-            "id": media_object.item.media_id,
-            "title": str(media_object.item),
-            "source": media_object.item.source,
-            "tvdbId": None,
-        }
         m = providers.services.get_media_metadata(
             media_type,
             media_object.item.media_id,
             media_object.item.source,
         )
-        item.update(
+        resp.append(
             {
+                "id": media_object.item.media_id,
+                "title": str(media_object.item),
+                "source": media_object.item.source,
+                "tvdbId": m.get("tvdb_id", None),
                 "max_progress": m["max_progress"],
                 "source_url": m["source_url"],
                 "image": m["image"],
@@ -390,9 +388,6 @@ def api_medialist(request, media_type):
                 "score_count": m["score_count"],
             },
         )
-        if "tvdb_id" in m:
-            item["tvdbId"] = str(m["tvdb_id"])
-        resp.append(item)
 
     return JsonResponse(
         resp,

--- a/src/integrations/views.py
+++ b/src/integrations/views.py
@@ -7,13 +7,16 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_not_required
 from django.core.exceptions import ObjectDoesNotExist
-from django.http import HttpResponse, StreamingHttpResponse
+from django.core.paginator import Paginator
+from django.http import HttpResponse, StreamingHttpResponse, JsonResponse
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_POST
 
+from app import providers
+from app.models import BasicMedia, MediaTypes
 import users
 from integrations import exports, tasks
 from integrations.imports import helpers, simkl, trakt
@@ -268,6 +271,7 @@ def import_steam(request):
         )
     return redirect("import_data")
 
+
 def import_imdb(request):
     """View for importing data from IMDB."""
     file = request.FILES.get("imdb_csv")
@@ -322,6 +326,63 @@ def export_csv(request):
     )
     logger.info("User %s started CSV export", request.user.username)
     return response
+
+
+@login_not_required
+@csrf_exempt
+@require_GET
+def api_medialist(request, media_type):
+    token = request.GET.get("token")
+    logger.info(token)
+    try:
+        request.user = users.models.User.objects.get(token=token)
+    except ObjectDoesNotExist:
+        logger.warning(
+            "Could not process API call: Invalid token: %s",
+            token,
+        )
+        return HttpResponse(status=401)
+    sort_filter = request.user.update_preference(
+        f"{media_type}_sort",
+        request.GET.get("sort"),
+    )
+    status_filter = request.user.update_preference(
+        f"{media_type}_status",
+        request.GET.get("status"),
+    )
+    logger.info(status_filter)
+    search_query = request.GET.get("search", "")
+    page = request.GET.get("page", 1)
+    media_queryset = BasicMedia.objects.get_media_list(
+        user=request.user,
+        media_type=media_type,
+        status_filter=status_filter,
+        sort_filter=sort_filter,
+        search=search_query,
+    )
+    items_per_page = 100
+    paginator = Paginator(media_queryset, items_per_page)
+    media_page = paginator.get_page(page)
+
+    resp = []
+
+    for object in media_page.object_list:
+        if media_type in [MediaTypes.TV.value, MediaTypes.ANIME.value]:
+            metadata = providers.services.get_media_metadata(
+                    media_type,
+                    object.item.media_id,
+                    object.item.source,
+                )
+            if "tvdb_id" in metadata:
+                resp.append({"tvdbId": str(metadata["tvdb_id"]), "title": str(object.item)})
+        else:
+            resp.append({"id": object.item.media_id, "title": str(object.item)})
+
+    return JsonResponse(
+        resp,
+        safe=False,
+        json_dumps_params={"ensure_ascii": False},
+    )
 
 
 @login_not_required


### PR DESCRIPTION
i was a little inspired by #488 and decided to spend a little while to make a very rudimentary endpoint for medialist.

the api key used for other integrations is what authorizes the call, though i stuck it into a query parameter rather than part of the url like the other integrations, because i didn't really want something looking like `/api/medialist/tv/apikeyhere`

i ran into some issues trying to set up every data provider (especially mal), so i haven't been able to test it properly-properly.

during my own testing, i tried using these endpoints in my *arr-stuff, just to see if i could use the endpoint as an import list, and import a tv series and a movie. this is my main motivation to be working on this (hence the camelCase keys.. lol). i believe these integrations ignore unfamiliar keys, so we could definitely expand on the return types, and make it more unified. e.g. this for every media type?

```python
{
    "id": media_id,
    "tvdbId": None if not tvdb_id else tvdb_id,
    "name": name,
    # etc.
}
```

i'll look into this a little bit, though i'm happy to receive feedback, and i'm also fine having this closed if it's super stupid to add to your codebase!