### PR TITLE
Clear search cache

### DIFF
--- a/src/templates/users/about.html
+++ b/src/templates/users/about.html
@@ -4,7 +4,7 @@
 {% load static %}
 
 {% block title %}
-  Account - Yamtrack
+  About - Yamtrack
 {% endblock title %}
 
 {% block settings_content %}

--- a/src/templates/users/advanced.html
+++ b/src/templates/users/advanced.html
@@ -1,0 +1,87 @@
+{% extends "users/base.html" %}
+
+{% load socialaccount %}
+{% load static %}
+
+{% block title %}
+    Advanced - Yamtrack
+{% endblock title %}
+
+{% block settings_content %}
+
+    <div class="space-y-6">
+        <div class="bg-[#2a2f35] rounded-lg p-6">
+            <div class="flex items-center mb-5">
+                <svg xmlns="http://www.w3.org/2000/svg"
+                     width="24"
+                     height="24"
+                     viewBox="0 0 24 24"
+                     fill="none"
+                     stroke="currentColor"
+                     stroke-width="2"
+                     stroke-linecap="round"
+                     stroke-linejoin="round"
+                     class="w-6 h-6 text-indigo-400 mr-3">
+                    <line x1="4" x2="4" y1="21" y2="14" /><line x1="4" x2="4" y1="10" y2="3" /><line x1="12" x2="12" y1="21" y2="12" /><line x1="12" x2="12" y1="8" y2="3" /><line x1="20" x2="20" y1="21" y2="16" /><line x1="20" x2="20" y1="12" y2="3" /><line x1="2" x2="6" y1="14" y2="14" /><line x1="10" x2="14" y1="8" y2="8" /><line x1="18" x2="22" y1="16" y2="16" />
+                </svg>
+                <h2 class="text-xl font-semibold">Advanced</h2>
+            </div>
+
+            <div class="bg-[#39404b] p-5 rounded-lg mb-6">
+                <div class="flex items-center mb-3">
+                    <svg xmlns="http://www.w3.org/2000/svg"
+                         width="24"
+                         height="24"
+                         viewBox="0 0 24 24"
+                         fill="none"
+                         stroke="currentColor"
+                         stroke-width="2"
+                         stroke-linecap="round"
+                         stroke-linejoin="round"
+                         class="w-5 h-5 text-indigo-400 mr-2">
+                        <path d="M10 11v6" />
+                        <path d="M14 11v6" />
+                        <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
+                        <path d="M3 6h18" />
+                        <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+                    </svg>
+                    <h3 class="text-base font-medium">Clear Search Cache</h3>
+                </div>
+                <p class="text-gray-400 mb-4 text-sm">
+                    Yamtrack stores your search results in a cache to speed up performance and reduce API calls.
+                    <br>
+                    Normally, these cached results expire automatically after 24 hours.
+                    If your search results appear outdated, you can clear the cache manually.
+                    <br>
+                    Your next search may be slightly slower as fresh data is retrieved.
+                </p>
+                <div class="flex space-x-3">
+                    <form method="post" action="{% url 'clear_search_cache' %}">
+                        {% csrf_token %}
+                        <button type="submit"
+                                class="flex items-center px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 transition-colors text-sm cursor-pointer">
+                            <svg xmlns="http://www.w3.org/2000/svg"
+                                 width="24"
+                                 height="24"
+                                 viewBox="0 0 24 24"
+                                 fill="none"
+                                 stroke="currentColor"
+                                 stroke-width="2"
+                                 stroke-linecap="round"
+                                 stroke-linejoin="round"
+                                 class="w-4 h-4 mr-2">
+                                <path d="M10 11v6" />
+                                <path d="M14 11v6" />
+                                <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
+                                <path d="M3 6h18" />
+                                <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+                            </svg>
+                            Clear Search Cache
+                        </button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+{% endblock settings_content %}

--- a/src/templates/users/base.html
+++ b/src/templates/users/base.html
@@ -133,6 +133,24 @@
               <span>Export Data</span>
             </a>
 
+            {% url 'advanced' as advanced_url %}
+            <a href="{{ advanced_url }}"
+               class="w-full flex items-center space-x-3 px-2 py-2 rounded-md transition-colors text-left border-l-2 cursor-pointer text-sm {% if request.path == advanced_url %}bg-[#39404b] text-white border-indigo-500{% else %}text-gray-400 border-transparent hover:bg-[#313842] hover:text-white{% endif %}">
+              <svg xmlns="http://www.w3.org/2000/svg"
+                   width="24"
+                   height="24"
+                   viewBox="0 0 24 24"
+                   fill="none"
+                   stroke="currentColor"
+                   stroke-width="2"
+                   stroke-linecap="round"
+                   stroke-linejoin="round"
+                   class="w-5 h-5">
+                <line x1="4" x2="4" y1="21" y2="14" /><line x1="4" x2="4" y1="10" y2="3" /><line x1="12" x2="12" y1="21" y2="12" /><line x1="12" x2="12" y1="8" y2="3" /><line x1="20" x2="20" y1="21" y2="16" /><line x1="20" x2="20" y1="12" y2="3" /><line x1="2" x2="6" y1="14" y2="14" /><line x1="10" x2="14" y1="8" y2="8" /><line x1="18" x2="22" y1="16" y2="16" />
+              </svg>
+              <span>Advanced</span>
+            </a>
+
             {% url 'about' as about_url %}
             <a href="{{ about_url }}"
                class="w-full flex items-center space-x-3 px-2 py-2 rounded-md transition-colors text-left border-l-2 cursor-pointer text-sm {% if request.path == about_url %}bg-[#39404b] text-white border-indigo-500{% else %}text-gray-400 border-transparent hover:bg-[#313842] hover:text-white{% endif %}">

--- a/src/users/urls.py
+++ b/src/users/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
     path("settings/integrations", views.integrations, name="integrations"),
     path("settings/import", views.import_data, name="import_data"),
     path("settings/export", views.export_data, name="export_data"),
+    path("settings/advanced", views.advanced, name="advanced"),
     path("settings/about", views.about, name="about"),
     path(
         "delete_import_schedule",
@@ -28,6 +29,7 @@ urlpatterns = [
         name="delete_import_schedule",
     ),
     path("regenerate_token", views.regenerate_token, name="regenerate_token"),
+    path("clear_search_cache", views.clear_search_cache, name="clear_search_cache"),
     path(
         "update_plex_usernames",
         views.update_plex_usernames,

--- a/src/users/views.py
+++ b/src/users/views.py
@@ -8,13 +8,12 @@ from django.core.cache import cache
 from django.db import IntegrityError
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect, render
-from django.views.decorators.http import (require_GET, require_http_methods,
-                                          require_POST)
+from django.template.defaultfilters import pluralize
+from django.views.decorators.http import require_GET, require_http_methods, require_POST
 from django_celery_beat.models import PeriodicTask
 
 from app.models import Item, MediaTypes
-from users.forms import (NotificationSettingsForm, PasswordChangeForm,
-                         UserUpdateForm)
+from users.forms import NotificationSettingsForm, PasswordChangeForm, UserUpdateForm
 
 logger = logging.getLogger(__name__)
 
@@ -261,7 +260,7 @@ def export_data(request):
 
 @require_GET
 def advanced(request):
-    """Render the advanced settings page"""
+    """Render the advanced settings page."""
     return render(request, "users/advanced.html")
 
 @require_GET
@@ -323,13 +322,16 @@ def update_plex_usernames(request):
 
 @require_POST
 def clear_search_cache(request):
-    """Clear all cached search entries"""
+    """Clear all cached search entries."""
     deleted = cache.delete_pattern("search_*")
 
-    messages.success(request, f"Successfully cleared {deleted} search entrie{'s' if deleted > 1 or deleted == 0 else ''}")
+    messages.success(
+        request,
+        f"Successfully cleared {deleted} search entr{pluralize(deleted, 'y,ies')}",
+    )
     logger.info(
         "Successfully cleared %s search entries",
         deleted,
     )
-    
+
     return redirect("advanced")

--- a/src/users/views.py
+++ b/src/users/views.py
@@ -4,18 +4,17 @@ import apprise
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import update_session_auth_hash
+from django.core.cache import cache
 from django.db import IntegrityError
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect, render
-from django.views.decorators.http import require_GET, require_http_methods, require_POST
+from django.views.decorators.http import (require_GET, require_http_methods,
+                                          require_POST)
 from django_celery_beat.models import PeriodicTask
 
 from app.models import Item, MediaTypes
-from users.forms import (
-    NotificationSettingsForm,
-    PasswordChangeForm,
-    UserUpdateForm,
-)
+from users.forms import (NotificationSettingsForm, PasswordChangeForm,
+                         UserUpdateForm)
 
 logger = logging.getLogger(__name__)
 
@@ -260,6 +259,10 @@ def export_data(request):
     """Render the export data settings page."""
     return render(request, "users/export_data.html")
 
+@require_GET
+def advanced(request):
+    """Render the advanced settings page"""
+    return render(request, "users/advanced.html")
 
 @require_GET
 def about(request):
@@ -317,3 +320,16 @@ def update_plex_usernames(request):
         messages.success(request, "Plex usernames updated successfully")
 
     return redirect("integrations")
+
+@require_POST
+def clear_search_cache(request):
+    """Clear all cached search entries"""
+    deleted = cache.delete_pattern("search_*")
+
+    messages.success(request, f"Successfully cleared {deleted} search entrie{'s' if deleted > 1 or deleted == 0 else ''}")
+    logger.info(
+        "Successfully cleared %s search entries",
+        deleted,
+    )
+    
+    return redirect("advanced")


### PR DESCRIPTION
This PR introduces an “Advanced” section in the settings page, where users can clear all cached search entries with a single click.
While cached searches normally expire automatically after 24 hours, it can be useful to refresh search results immediately.
For example, if a book isn’t found, I'll add it to Hardcover within minutes and then want updated search results without waiting the full expiration period.

<img width="1191" height="467" alt="Screenshot 2025-08-15 013833" src="https://github.com/user-attachments/assets/816b4b8d-e928-477a-ab7e-9f3994b45e79" />

<img width="1208" height="501" alt="Screenshot 2025-08-15 013843" src="https://github.com/user-attachments/assets/f01e63e1-8770-4f67-a8fa-b3b65be1032d" />
