### PR TITLE
Display runtime for each episode

### DIFF
--- a/src/app/providers/tmdb.py
+++ b/src/app/providers/tmdb.py
@@ -549,7 +549,7 @@ def process_episodes(season_metadata, episodes_in_db):
                 "title": episode["name"],
                 "overview": episode["overview"],
                 "history": tracked_episodes.get(episode_number, []),
-                "runtime": episode["runtime"],
+                "runtime": get_readable_duration(episode["runtime"]),
             },
         )
     return episodes_metadata

--- a/src/app/providers/tmdb.py
+++ b/src/app/providers/tmdb.py
@@ -549,6 +549,7 @@ def process_episodes(season_metadata, episodes_in_db):
                 "title": episode["name"],
                 "overview": episode["overview"],
                 "history": tracked_episodes.get(episode_number, []),
+                "runtime": episode["runtime"],
             },
         )
     return episodes_metadata

--- a/src/app/templatetags/app_tags.py
+++ b/src/app/templatetags/app_tags.py
@@ -9,6 +9,7 @@ from unidecode import unidecode
 
 from app import media_type_config
 from app.models import MediaTypes, Sources, Status
+from app.providers.tmdb import get_readable_duration
 
 register = template.Library()
 
@@ -434,3 +435,7 @@ def get_pagination_range(current_page, total_pages, window):
         result.append(total_pages)
 
     return result
+
+@register.filter
+def readable_duration(value):
+    return get_readable_duration(value)

--- a/src/app/templatetags/app_tags.py
+++ b/src/app/templatetags/app_tags.py
@@ -9,7 +9,6 @@ from unidecode import unidecode
 
 from app import media_type_config
 from app.models import MediaTypes, Sources, Status
-from app.providers.tmdb import get_readable_duration
 
 register = template.Library()
 
@@ -435,7 +434,3 @@ def get_pagination_range(current_page, total_pages, window):
         result.append(total_pages)
 
     return result
-
-@register.filter
-def readable_duration(value):
-    return get_readable_duration(value)

--- a/src/templates/app/media_details.html
+++ b/src/templates/app/media_details.html
@@ -669,7 +669,7 @@
                       <div>
                         <h2 class="text-xl font-semibold mb-1 line-clamp-1">{{ episode.title }}</h2>
                         <p class="text-sm text-gray-400">
-                          Episode {{ episode.episode_number }} • {{ episode.air_date|default_if_none:"Unknown air date" }}{% if episode.runtime %} • {{ episode.runtime|readable_duration }}{% endif %}
+                          Episode {{ episode.episode_number }} • {{ episode.air_date|default_if_none:"Unknown air date" }}{% if episode.runtime %} • {{ episode.runtime }}{% endif %}
                         </p>
                       </div>
                       <div class="flex space-x-2">

--- a/src/templates/app/media_details.html
+++ b/src/templates/app/media_details.html
@@ -669,7 +669,7 @@
                       <div>
                         <h2 class="text-xl font-semibold mb-1 line-clamp-1">{{ episode.title }}</h2>
                         <p class="text-sm text-gray-400">
-                          Episode {{ episode.episode_number }} • {{ episode.air_date|default_if_none:"Unknown air date" }}
+                          Episode {{ episode.episode_number }} • {{ episode.air_date|default_if_none:"Unknown air date" }}{% if episode.runtime %} • {{ episode.runtime|readable_duration }}{% endif %}
                         </p>
                       </div>
                       <div class="flex space-x-2">


### PR DESCRIPTION
Display the runtime on each episode in a season overview. Since runtimes may differ a lot over a season, this gives a better overview than just the average runtime of the season.

Styling looks a little weird on mobile, since the line is now longer and sometimes needs to fold. But there are already issues with styling on small screens (can't read full episode titles in many cases), so leaving that for another PR.

<details>
<summary>Mobile styling examples</summary>

360px wide (Galaxy S20):
<img width="315" height="378" alt="image" src="https://github.com/user-attachments/assets/919cb11f-7a72-42c9-95d3-2af83326c59b" />

414px wide (iPhone 11 Pro Max):
<img width="364" height="387" alt="image" src="https://github.com/user-attachments/assets/697df1ff-ee25-4f34-8692-aab0835fe13f" />


</details>

Closes #804.

## Screenshots
Before:
<img width="707" height="176" alt="image" src="https://github.com/user-attachments/assets/6cc7e887-8028-4249-82a4-ef1186458d01" />

After:
<img width="707" height="176" alt="image" src="https://github.com/user-attachments/assets/3f2c2e90-3f1a-4db1-9133-4628c5b96144" />



