### PR TITLE
Support setting Redis prefix using environmental variable REDIS_PREFIX

### DIFF
--- a/src/app/providers/services.py
+++ b/src/app/providers/services.py
@@ -34,10 +34,13 @@ def get_redis_connection():
 
 redis_pool = get_redis_connection()
 
+REDIS_PREFIX = getattr(settings, "REDIS_PREFIX", None)
+bucket_name = f"{REDIS_PREFIX}_api" if REDIS_PREFIX else "api"
+
 session = LimiterSession(
     per_second=5,
     bucket_class=RedisBucket,
-    bucket_kwargs={"redis_pool": redis_pool, "bucket_name": "api"},
+    bucket_kwargs={"redis_pool": redis_pool, "bucket_name": bucket_name},
 )
 
 session.mount("http://", HTTPAdapter(max_retries=3))

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -22,6 +22,8 @@ BASE_URL = config("BASE_URL", default=None)
 if BASE_URL:
     FORCE_SCRIPT_NAME = BASE_URL
 
+REDIS_PREFIX = config("REDIS_PREFIX", default=None)
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -211,12 +213,14 @@ else:
 # https://docs.djangoproject.com/en/stable/topics/cache/
 CACHE_TIMEOUT = 86400  # 24 hours
 REDIS_URL = config("REDIS_URL", default="redis://localhost:6379")
+KEY_PREFIX = f"{REDIS_PREFIX}" if REDIS_PREFIX else ""
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": REDIS_URL,
         "TIMEOUT": CACHE_TIMEOUT,
         "VERSION": 10,
+        "KEY_PREFIX": KEY_PREFIX,
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         },
@@ -453,6 +457,12 @@ SELECT2_THEME = "tailwindcss-4"
 
 CELERY_BROKER_URL = REDIS_URL
 CELERY_TIMEZONE = TIME_ZONE
+
+if REDIS_PREFIX:
+    CELERY_BROKER_TRANSPORT_OPTIONS = {
+        "global_keyprefix": f"{REDIS_PREFIX}",
+        "queue_prefix": f"{REDIS_PREFIX}",
+    }
 
 CELERY_WORKER_HIJACK_ROOT_LOGGER = False
 CELERY_WORKER_CONCURRENCY = 1


### PR DESCRIPTION
Redis does ACL using key and channel prefixes, if multiple apps and services were to use the same Redis instance as cache, the only way to enforce some kind of isolation and permission control between these apps and services is to set appropriate prefixes in them and control the permission in Redis. 

This PR introduces a environmental variable REDIS_PREFIX, and adds corresponding prefixes for Django, Celery and Yamtrack's own session keys and channels. 