### PR TITLE
Fix tab order for password change form

### DIFF
--- a/src/templates/users/account.html
+++ b/src/templates/users/account.html
@@ -108,6 +108,7 @@
                    :type="showCurrentPassword ? 'text' : 'password'"
                    value="">
             <button type="button"
+                    tabindex="-1"
                     @click="showCurrentPassword = !showCurrentPassword"
                     class="absolute inset-y-0 right-0 px-3 flex items-center text-gray-400 hover:text-white cursor-pointer">
               <!-- Show when password is hidden -->
@@ -159,6 +160,7 @@
                    :type="showNewPassword ? 'text' : 'password'"
                    value="">
             <button type="button"
+                    tabindex="-1"
                     @click="showNewPassword = !showNewPassword"
                     class="absolute inset-y-0 right-0 px-3 flex items-center text-gray-400 hover:text-white cursor-pointer">
               <!-- Show when password is hidden -->
@@ -210,6 +212,7 @@
                    :type="showConfirmPassword ? 'text' : 'password'"
                    value="">
             <button type="button"
+                    tabindex="-1"
                     @click="showConfirmPassword = !showConfirmPassword"
                     class="absolute inset-y-0 right-0 px-3 flex items-center text-gray-400 hover:text-white cursor-pointer">
               <!-- Show when password is hidden -->


### PR DESCRIPTION
This is the same fix as #776, but for the password change form instead of the signup form.