### PR TITLE
Optional settings for MAL titles

### DIFF
--- a/src/app/providers/mal.py
+++ b/src/app/providers/mal.py
@@ -72,7 +72,7 @@ def search(media_type, query, page):
                 "media_id": media["node"]["id"],
                 "source": Sources.MAL.value,
                 "media_type": media_type,
-                "title": get_english_title_if_available(media["node"]),
+                "title": get_title(media["node"]),
                 "image": get_image_url(media["node"]),
             }
             for media in response
@@ -119,7 +119,7 @@ def anime(media_id):
             "source": Sources.MAL.value,
             "source_url": f"https://myanimelist.net/anime/{media_id}",
             "media_type": MediaTypes.ANIME.value,
-            "title": get_english_title_if_available(response),
+            "title": get_title(response),
             "max_progress": num_episodes,
             "image": get_image_url(response),
             "synopsis": get_synopsis(response),
@@ -183,7 +183,7 @@ def manga(media_id):
             "source": Sources.MAL.value,
             "source_url": f"https://myanimelist.net/manga/{media_id}",
             "media_type": MediaTypes.MANGA.value,
-            "title": response["title"],
+            "title": get_title(response),
             "image": get_image_url(response),
             "synopsis": get_synopsis(response),
             "max_progress": num_chapters,
@@ -385,7 +385,7 @@ def get_related(related_medias, media_type):
             {
                 "media_id": media["node"]["id"],
                 "source": Sources.MAL.value,
-                "title": get_english_title_if_available(media["node"], media["node"]["id"]),
+                "title": get_title(media["node"]),
                 "media_type": media_type,
                 "image": get_image_url(media["node"]),
             }
@@ -394,7 +394,7 @@ def get_related(related_medias, media_type):
     return []
 
 
-def get_english_title_if_available(media, media_id = None):
+def get_title(media):
     """Return the English title if available, otherwise return the main title."""
     if settings.MAL_PREFER_EN_TITLE:
         alternative_titles = media.get("alternative_titles", {})

--- a/src/app/providers/mal.py
+++ b/src/app/providers/mal.py
@@ -12,7 +12,7 @@ from app.providers import services
 
 logger = logging.getLogger(__name__)
 base_url = "https://api.myanimelist.net/v2"
-base_fields = "title,main_picture,media_type,start_date,end_date,synopsis,status,genres,mean,num_scoring_users,recommendations"  # noqa: E501
+base_fields = "title,main_picture,media_type,start_date,end_date,synopsis,status,genres,mean,num_scoring_users,recommendations,alternative_titles"  # noqa: E501
 
 
 def handle_error(error):
@@ -49,7 +49,7 @@ def search(media_type, query, page):
         url = f"{base_url}/{media_type}"
         params = {
             "q": query,
-            "fields": "media_type",
+            "fields": "media_type,alternative_titles",
             "limit": settings.PER_PAGE,
         }
         if settings.MAL_NSFW:
@@ -72,7 +72,7 @@ def search(media_type, query, page):
                 "media_id": media["node"]["id"],
                 "source": Sources.MAL.value,
                 "media_type": media_type,
-                "title": media["node"]["title"],
+                "title": get_english_title_if_available(media["node"]),
                 "image": get_image_url(media["node"]),
             }
             for media in response
@@ -119,7 +119,7 @@ def anime(media_id):
             "source": Sources.MAL.value,
             "source_url": f"https://myanimelist.net/anime/{media_id}",
             "media_type": MediaTypes.ANIME.value,
-            "title": response["title"],
+            "title": get_english_title_if_available(response),
             "max_progress": num_episodes,
             "image": get_image_url(response),
             "synopsis": get_synopsis(response),
@@ -149,7 +149,6 @@ def anime(media_id):
                 ),
             },
         }
-
         cache.set(cache_key, data)
 
     return data
@@ -386,10 +385,18 @@ def get_related(related_medias, media_type):
             {
                 "media_id": media["node"]["id"],
                 "source": Sources.MAL.value,
-                "title": media["node"]["title"],
+                "title": get_english_title_if_available(media["node"], media["node"]["id"]),
                 "media_type": media_type,
                 "image": get_image_url(media["node"]),
             }
             for media in related_medias
         ]
     return []
+
+
+def get_english_title_if_available(media, media_id = None):
+    """Return the English title if available, otherwise return the main title."""
+    if settings.MAL_PREFER_EN_TITLE:
+        alternative_titles = media.get("alternative_titles", {})
+        return alternative_titles.get("en") or media.get("title")
+    return media.get("title")

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -343,6 +343,8 @@ MAL_API = config(
 )
 MAL_NSFW = config("MAL_NSFW", default=False, cast=bool)
 
+MAL_PREFER_EN_TITLE = config("MAL_PREFER_EN_TITLE", default=False, cast=bool)
+
 MU_NSFW = config("MU_NSFW", default=False, cast=bool)
 
 IGDB_ID = config(


### PR DESCRIPTION
Addresses #801 

Introduces a new environment variable MAL_PREFER_EN_TITLE with default set to False, making this an opt in feature so as to not affect existing setups.

Titles in Media List and Media Details will automatically use the English titles from the MAL API, if they are available.

This PR does not affect Recommended or Related lists as the API response does not contain alternate titles. Manually querying each title in the Recommended and Related lists results in rate limiting from the MAL API which leads to a slow user experience and probably frowned upon by MAL, so decided against including it, even as an option.

<img width="1825" height="850" alt="image" src="https://github.com/user-attachments/assets/4e433436-0d38-4f7f-9607-0328114decaa" />
<img width="1750" height="996" alt="image" src="https://github.com/user-attachments/assets/d729a4ac-de4a-4e4f-afb5-18d755fd190a" />


<img width="1685" height="400" alt="image" src="https://github.com/user-attachments/assets/886e3a81-2431-4c0b-97f0-f58de9ca1a51" />
<img width="1685" height="419" alt="image" src="https://github.com/user-attachments/assets/ce877d31-576c-4e03-8ee6-453daf07ffc5" />

