### PR TITLE
Allow importing TV seasons/episodes by title

### DIFF
--- a/src/app/providers/services.py
+++ b/src/app/providers/services.py
@@ -190,6 +190,8 @@ def search(media_type, query, page, source=None):
         response = mal.search(media_type, query, page)
     elif media_type in (MediaTypes.TV.value, MediaTypes.MOVIE.value):
         response = tmdb.search(media_type, query, page)
+    elif media_type in (MediaTypes.SEASON.value, MediaTypes.EPISODE.value):
+        response = tmdb.search(MediaTypes.TV.value, query, page)
     elif media_type == MediaTypes.GAME.value:
         response = igdb.search(query, page)
     elif media_type == MediaTypes.BOOK.value:


### PR DESCRIPTION
Currently, when importing a TV show (or a movie) via a Yamtrack-compatible CSV file, 'media_id' is optional. If it is not provided, TMDB will be searched for the show Title.

However, the same is not true when importing TV seasons and episodes. If 'media_id' is not provided, the import will result in an error.

This small change allows specifying a show title, without specifying a media_id when importing seasons and episodes.