### PR TITLE
Hide media card hover buttons on touch devices

### DIFF
--- a/src/app/tests/test_integration.py
+++ b/src/app/tests/test_integration.py
@@ -44,9 +44,9 @@ class IntegrationTest(StaticLiveServerTestCase):
         self.page.get_by_placeholder("Search tv shows...").fill("breaking bad")
         self.page.get_by_role("button").nth(1).click()
         expect(self.page.locator("h2")).to_contain_text("Search Results")
-        self.page.get_by_role("link", name="Breaking Bad", exact=True).click()
+        self.page.get_by_title("Breaking Bad", exact=True).click()
         expect(self.page.get_by_role("main")).to_contain_text("Breaking Bad")
-        self.page.get_by_role("link", name="Season 1").click()
+        self.page.get_by_title("Season 1").click()
         expect(self.page.get_by_role("main")).to_contain_text("Season 1")
         self.page.locator(".p-2").first.click()
         expect(self.page.get_by_role("main")).to_contain_text("Track Episode")
@@ -60,7 +60,7 @@ class IntegrationTest(StaticLiveServerTestCase):
         self.page.get_by_text("Breaking Bad S1 1 Episode").get_by_role("button").nth(
             1,
         ).click()
-        self.page.get_by_role("link", name="Breaking Bad S1").click()
+        self.page.get_by_title("Breaking Bad S1").click()
 
         today = formats.date_format(
             timezone.localdate(),
@@ -76,7 +76,7 @@ class IntegrationTest(StaticLiveServerTestCase):
             "button",
         ).first.click()
         expect(self.page.locator("h2")).to_contain_text("Search Results")
-        self.page.get_by_role("link", name="Breaking Bad", exact=True).click()
+        self.page.get_by_title("Breaking Bad", exact=True).click()
         expect(self.page.get_by_role("main")).to_contain_text("Breaking Bad")
         self.page.locator("button").filter(has_text="Add to tracker").click()
         expect(self.page.locator("#track-tv-1396")).to_contain_text("Score")
@@ -91,9 +91,9 @@ class IntegrationTest(StaticLiveServerTestCase):
         self.page.get_by_placeholder("Search tv shows...").fill("breaking bad")
         self.page.get_by_role("button").nth(1).click()
         expect(self.page.locator("h2")).to_contain_text("Search Results")
-        self.page.get_by_role("link", name="Breaking Bad", exact=True).click()
+        self.page.get_by_title("Breaking Bad", exact=True).click()
         expect(self.page.get_by_role("main")).to_contain_text("Breaking Bad")
-        self.page.get_by_role("link", name="Season 1").click()
+        self.page.get_by_title("Season 1").click()
         expect(self.page.get_by_role("main")).to_contain_text("Season 1")
         self.page.get_by_role("button", name="Add to tracker").click()
         expect(self.page.locator("#track-season-1396-1")).to_contain_text("Score")
@@ -162,10 +162,10 @@ class IntegrationTest(StaticLiveServerTestCase):
         self.page.get_by_role("link", name="Grid View").click()
         expect(self.page.get_by_role("main")).to_contain_text("Friends S1")
         self.page.get_by_role("link", name="TV Shows").click()
-        self.page.get_by_role("link", name="Friends").click()
+        self.page.get_by_title("Friends").click()
         expect(self.page.get_by_role("main")).to_contain_text("Friends")
         expect(self.page.get_by_role("main")).to_contain_text("Season 1")
-        self.page.get_by_role("link", name="Season 1").click()
+        self.page.get_by_title("Season 1").click()
         expect(self.page.get_by_role("main")).to_contain_text("Season 1")
         expect(self.page.get_by_role("main")).to_contain_text(
             "Episode 1 • Unknown air date",

--- a/src/static/css/main.css
+++ b/src/static/css/main.css
@@ -2663,6 +2663,11 @@
       flex-direction: column;
     }
   }
+  .pointer-coarse\:hidden {
+    @media (pointer: coarse) {
+      display: none;
+    }
+  }
   .hover-tap\:opacity-100 {
     &:hover {
       opacity: 100%;

--- a/src/templates/app/components/home_grid.html
+++ b/src/templates/app/components/home_grid.html
@@ -4,10 +4,12 @@
   <div class="bg-[#2a2f35] rounded-lg overflow-hidden shadow-lg transition-all duration-300"
        x-data="{ trackOpen: false, listsOpen: false, historyOpen: false }">
     <div class="relative">
+      <a href="{{ media.item|media_url }}">
       <img alt="{{ media }}"
            class="lazyload w-full aspect-2/3 {% if media.item.image != IMG_NONE %}object-cover{% endif %}"
            data-src="{{ media.item.image }}"
            src="{{ IMG_NONE }}">
+      </a>
 
       {% if media.next_event and not media.next_event.is_max_datetime %}
         <div class="absolute top-2 left-1/2 -translate-x-1/2 flex items-center gap-1.5 bg-black/80 px-2 py-1.5 rounded-md shadow-md whitespace-nowrap max-w-[98%]">
@@ -24,7 +26,7 @@
         </div>
       {% endif %}
 
-      <div class="absolute inset-0 bg-black/50 flex items-center justify-center opacity-0 hover-tap:opacity-100">
+      <div class="absolute inset-0 bg-black/50 flex items-center justify-center opacity-0 hover-tap:opacity-100 pointer-coarse:hidden">
         <a href="{{ media.item|media_url }}" class="absolute inset-0"></a>
 
         <div class="relative flex items-center justify-center space-x-2.5">

--- a/src/templates/app/components/media_card.html
+++ b/src/templates/app/components/media_card.html
@@ -3,10 +3,12 @@
 <div class="{% if secondary_color %}bg-[#39404b]{% else %}bg-[#2a2f35]{% endif %} rounded-lg overflow-hidden shadow-lg relative"
      x-data="{ trackOpen: false, listsOpen: false, historyOpen: false }">
   <div class="relative">
+    <a href="{{ item|media_url }}">
     <img alt="{{ title }}"
          class="lazyload w-full {% if from_grid %}aspect-2/3{% else %}h-48{% endif %} bg-[#3e454d] {% if item.image != IMG_NONE %}object-cover{% endif %}"
          data-src="{{ item.image }}"
          src="{{ IMG_NONE }}">
+    </a>
 
     {% if media.status %}
       <div class="absolute top-2 left-2 bg-gray-900/90 text-white text-xs px-2 py-1 rounded-md flex items-center shadow-md">
@@ -67,7 +69,7 @@
       </div>
     {% endif %}
 
-    <div class="absolute inset-0 bg-black/50 flex items-center justify-center opacity-0 hover-tap:opacity-100">
+    <div class="absolute inset-0 bg-black/50 flex items-center justify-center opacity-0 hover-tap:opacity-100 pointer-coarse:hidden">
       <a href="{{ item|media_url }}" class="absolute inset-0"></a>
 
       <div class="relative flex items-center justify-center space-x-2.5">


### PR DESCRIPTION
## Description of changes

When hovering over the image on media cards, three buttons are shown for tracking, lists, and history. This works great on desktop, but on mobile there is no hover state so they aren't shown. Worse, when tapping the image where the invisible buttons are, you will press the button instead of navigating to the media details page as intended.

This PR hides the entire overlay and the buttons on touch devices (`pointer-coarse`), and adds a link to the `img` itself in addition to the overlay so you can still navigate to the details page when the overlay is hidden. This removes the accidental button clicks on mobile.