### PR TITLE
Display movie collections on media detail page

### DIFF
--- a/src/app/providers/tmdb.py
+++ b/src/app/providers/tmdb.py
@@ -141,8 +141,26 @@ def movie(media_id):
                 url,
                 params=params,
             )
+
+            if response.get("belongs_to_collection", {}) is not None and (
+            collection_id := response.get("belongs_to_collection", {}).get("id")):
+                collection_response = services.api_request(
+                    Sources.TMDB.value,
+                    "GET",
+                    f"{base_url}/collection/{collection_id}",
+                    params={**base_params},
+                )
+            else:
+                collection_response = {}
         except requests.exceptions.HTTPError as error:
             handle_error(error)
+
+        # Filter out collection items from recommendations, to avoid duplicates
+        collection_items = get_collection(collection_response)
+        collection_ids = [item["media_id"] for item in collection_items]
+        recommended_items = response.get("recommendations", {}).get("results", [])
+        filtered_recommendations = [item for item in recommended_items
+                                    if item["id"] not in collection_ids]
 
         data = {
             "media_id": media_id,
@@ -166,8 +184,9 @@ def movie(media_id):
                 "languages": get_languages(response["spoken_languages"]),
             },
             "related": {
+                collection_response.get("name", "collection"): collection_items,
                 "recommendations": get_related(
-                    response.get("recommendations", {}).get("results", [])[:15],
+                    filtered_recommendations[:15],
                     MediaTypes.MOVIE.value,
                 ),
             },
@@ -556,6 +575,23 @@ def get_related(related_medias, media_type, parent_response=None):
         related.append(data)
     return related
 
+
+def get_collection(collection_response):
+    """Format media collection list to match related media."""
+    def date_key(media):
+        date = media.get("release_date", "")
+        if date is None or date == "":
+            # If release date is unknown, sort by title after known releases
+            title = get_title(media)
+            date = f"9999-99-99-{title}"
+        return date
+
+    parts = sorted(collection_response.get("parts", []), key=date_key)
+    return [{"source": Sources.TMDB.value,
+             "media_type": MediaTypes.MOVIE.value,
+             "image": get_image_url(media["poster_path"]),
+             "media_id": media["id"],
+             "title": get_title(media)} for media in parts]
 
 def process_episodes(season_metadata, episodes_in_db):
     """Process the episodes for the selected season."""

--- a/src/templates/app/components/media_card.html
+++ b/src/templates/app/components/media_card.html
@@ -1,6 +1,6 @@
 {% load app_tags %}
 
-<div class="{% if secondary_color %}bg-[#39404b]{% else %}bg-[#2a2f35]{% endif %} rounded-lg overflow-hidden shadow-lg relative"
+<div class="{% if secondary_color %}bg-[#39404b]{% else %}bg-[#2a2f35]{% endif %} rounded-lg overflow-hidden shadow-lg relative {% if active %}ring-2 ring-indigo-700{% endif %}"
      x-data="{ trackOpen: false, listsOpen: false, historyOpen: false }">
   <div class="relative">
     <img alt="{{ title }}"

--- a/src/templates/app/media_details.html
+++ b/src/templates/app/media_details.html
@@ -468,7 +468,12 @@
               <h2 class="text-xl font-bold mb-4">{{ name|no_underscore|title }}</h2>
               <div class="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-4">
                 {% for result in related_items %}
-                  {% include "app/components/media_card.html" with item=result.item title=result.item.season_title|default:result.item.title media=result.media %}
+                  {% if media_type != MediaTypes.TV.value and media_type != MediaTypes.SEASON.value %}
+                    {# Set active to highlight the current movie in a collection. Avoid TV media, since seasons have same ID as the parent show #}
+                    {% include "app/components/media_card.html" with item=result.item title=result.item.season_title|default:result.item.title media=result.media active=media.media_id|str_equals:result.item.media_id %}
+                  {% else %}
+                    {% include "app/components/media_card.html" with item=result.item title=result.item.season_title|default:result.item.title media=result.media %}
+                  {% endif %}
                 {% endfor %}
               </div>
             </section>


### PR DESCRIPTION
## Description of changes

TMDB has the concept of "collections", which contains movies that are prequels/sequels to eachother. This PR checks a movies metadata if it belongs to a collection, and if it does displays the movies in the collection on the media detail page.

- Hooks into the existing "related" framework as an extra category, so minimal changes are needed in the templates
- Movies in the collection are removed from the recommendations to avoid duplicates
- The current movie in the collection is highlighted

<img width="1444" height="843" alt="image" src="https://github.com/user-attachments/assets/f76a8312-bf54-4bad-b692-59f2f32cde4e" />


## Notes
The collection data can't be fetched using `append_to_response`, since the main metadata must be fetched first to know if there is a collection at all. So for movies with a collection there will be two API requests.

The check for which movie in a collection is the currently viewed movie introduced an if-else statement for the `media_card` component. This is because the active ring around the current movie is added when the media ID matches the collection item ID. But TV seasons are also rendered in this related items loop, and a TV seasons ID is the same as the TV show ID, so all seasons would get the active ring even though they are not part of a collection at all. I didn't see an easy way to fix this without separating out either seasons or collections from other related items, so I went for an if-else instead even though it isn't super DRY.

Collections usually only contain direct sequels/prequels, so for example there is an "Iron Man" collection but no MCU collection, and the "Star Wars" collection contains only the Skywalker saga and not movies like "Rogue One" and "Solo". If you want to check out how these changes look with a large collection, look at any James Bond movie, as they are all part of the same collection (25ish movies).