### PR TITLE
Hide completed related media if HIDE_COMPLETED is set

### DIFF
--- a/src/app/helpers.py
+++ b/src/app/helpers.py
@@ -1,6 +1,7 @@
 from urllib.parse import parse_qsl, urlencode, urlparse
 
 from django.apps import apps
+from django.conf import settings
 from django.contrib import messages
 from django.db.models import Q
 from django.http import HttpResponseRedirect
@@ -8,8 +9,9 @@ from django.shortcuts import redirect
 from django.utils.encoding import iri_to_uri
 from django.utils.http import url_has_allowed_host_and_scheme
 
-from app.models import BasicMedia, MediaTypes
+from app.models import BasicMedia, MediaTypes, Status
 
+hide_completed = settings.HIDE_COMPLETED
 
 def minutes_to_hhmm(total_minutes):
     """Convert total minutes to HH:MM format."""
@@ -118,9 +120,13 @@ def enrich_items_with_user_data(request, items):
         else:
             key = (str(item["media_id"]), item["source"])
 
+        media_item = media_lookup.get(key)
+        if hide_completed and media_type != MediaTypes.SEASON.value and media_item and media_item.status == Status.COMPLETED.value:
+            continue
+
         enriched_item = {
             "item": item,
-            "media": media_lookup.get(key),
+            "media": media_item,
         }
         enriched_items.append(enriched_item)
 

--- a/src/app/helpers.py
+++ b/src/app/helpers.py
@@ -68,7 +68,7 @@ def format_search_response(page, per_page, total_results, results):
     }
 
 
-def enrich_items_with_user_data(request, items):
+def enrich_items_with_user_data(request, items, section_name = None):
     """Enrich a list of items with user tracking data."""
     if not items:
         return []
@@ -121,7 +121,7 @@ def enrich_items_with_user_data(request, items):
             key = (str(item["media_id"]), item["source"])
 
         media_item = media_lookup.get(key)
-        if hide_completed and media_type != MediaTypes.SEASON.value and media_item and media_item.status == Status.COMPLETED.value:
+        if hide_completed and section_name == "recommendations" and media_item and media_item.status == Status.COMPLETED.value:
             continue
 
         enriched_item = {

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -211,6 +211,7 @@ def media_details(request, source, media_type, media_id, title):  # noqa: ARG001
                     helpers.enrich_items_with_user_data(
                         request,
                         related_items,
+                        section_name
                     )
                 )
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -328,6 +328,8 @@ IMG_NONE = "https://www.themoviedb.org/assets/2/v4/glyphicons/basic/glyphicons-b
 REQUEST_TIMEOUT = 120  # seconds
 PER_PAGE = 24
 
+HIDE_COMPLETED = config("HIDE_COMPLETED", default=False, cast=bool)
+
 TMDB_API = config(
     "TMDB_API",
     default=secret(


### PR DESCRIPTION
Added HIDE_COMPLETED to the environment variables in order to hide related completed media in the detail page.
This resolves #964. I didn't filtered it movies, I think it makes sense in all media types (except seasons, i filtered those out).

Question: how can I add this info to the project's wiki? Or will you be adding this info?