### PR TITLE
Fix igdb search retry after getting new access token

### DIFF
--- a/src/app/providers/igdb.py
+++ b/src/app/providers/igdb.py
@@ -229,7 +229,7 @@ def search(query, page):
                     Sources.IGDB.value,
                     "POST",
                     url,
-                    data=data,
+                    data=multiquery,
                     headers=headers,
                 )
 


### PR DESCRIPTION
This PR fixes the following ticket: #1036