### PR TITLE
Add IPv6 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ COPY ./requirements.txt /requirements.txt
 COPY ./entrypoint.sh /entrypoint.sh
 COPY ./supervisord.conf /etc/supervisord.conf
 COPY ./nginx.conf /etc/nginx/nginx.conf
+# Generate a copy of the nginx config with IPv6 support.
+RUN sed 's/listen 8000;/listen 8000; listen [::]:8000;/' /etc/nginx/nginx.conf > /etc/nginx/nginx.ipv6.conf
 
 WORKDIR /yamtrack
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -3,7 +3,7 @@ nodaemon=true
 user=root
 
 [program:nginx]
-command=nginx -g 'daemon off;'
+command=sh -c 'if [ "${YAMTRACK_IPV6_ENABLED:-False}" = "True" ]; then CONF=/etc/nginx/nginx.ipv6.conf; else CONF=/etc/nginx/nginx.conf; fi; nginx -c $CONF -g "daemon off;"'
 user=root
 priority=1
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
This change remains backward compatible, as IPv6 support is disabled by default.

Nginx fails to start when an IPv6 `listen` directive is specified on an
IPv4-only host, preventing a single configuration from supporting both
protocols. To work around this limitation, the Docker image build
process now generates a separate copy of the Nginx configuration for IPv6.

An environment variable can be used to select either the IPv4 or IPv6
configuration when launching the container.

By embedding both configurations during the image build, we avoid making
file system changes at runtime — a step toward an immutable filesystem design.

### TODO
- [ ] Update [Environment Variables Wiki page](https://github.com/FuzzyGrim/Yamtrack/wiki/Environment-Variables) with new environment variable 