### PR TITLE
[Feature] Support Plex HAMA agent for anime series

### DIFF
--- a/src/integrations/tests/test_webhooks_plex.py
+++ b/src/integrations/tests/test_webhooks_plex.py
@@ -378,6 +378,37 @@ class PlexWebhookTests(TestCase):
                     self.assertEqual(response.status_code, 200)
                     self.assertEqual(Movie.objects.count(), 0)
 
+    def test_anime_episode_anidb_guid_mark_played(self):
+        """Test webhook handles anime episode with anidb guid."""
+        payload = {
+            "event": "media.scrobble",
+            "Account": {"title": "testuser"},
+            "Metadata": {
+                "type": "episode",
+                "index": 1,
+                "parentIndex": 1,
+                "guid": "com.plexapp.agents.hama://anidb-3651/1/1?lang=en"
+            },
+        }
+
+        data = {"payload": json.dumps(payload)}
+
+        response = self.client.post(
+            self.url,
+            data=data,
+            format="multipart",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # Verify anime was created and marked as in progress
+        anime = Anime.objects.get(
+            item__media_id="849",
+            user=self.user,
+        )
+        self.assertEqual(anime.status, Status.IN_PROGRESS.value)
+        self.assertEqual(anime.progress, 1)
+
     def test_extract_external_ids(self):
         """Test extraction of external IDs from Plex webhook payload."""
         # Setup test payload
@@ -399,11 +430,32 @@ class PlexWebhookTests(TestCase):
             "tmdb_id": "12345",
             "imdb_id": "tt67890",
             "tvdb_id": "98765",
+            "anidb_id": None,
         }
 
-        if result != expected:
-            msg = f"Expected {expected}, got {result}"
-            raise AssertionError(msg)
+        self.assertEqual(result, expected)
+
+    def test_extract_external_ids_from_guid_string(self):
+        """Test extraction of external IDs from Plex webhook payload."""
+        # Setup test payload
+        payload = {
+            "Metadata": {
+                "guid": "com.plexapp.agents.hama://anidb-12345/1/1?lang=en",
+            },
+        }
+
+        # Execute
+        result = PlexWebhookProcessor()._extract_external_ids(payload)
+
+        # Assert
+        expected = {
+            "tmdb_id": None,
+            "imdb_id": None,
+            "tvdb_id": None,
+            "anidb_id": "12345",
+        }
+
+        self.assertEqual(result, expected)
 
     def test_extract_external_ids_missing_data(self):
         """Test handling of missing or empty data."""
@@ -415,7 +467,6 @@ class PlexWebhookTests(TestCase):
             "tmdb_id": None,
             "imdb_id": None,
             "tvdb_id": None,
+            "anidb_id": None,
         }
-        if result != expected:
-            msg = f"Expected {expected}, got {result}"
-            raise AssertionError(msg)
+        self.assertEqual(result, expected)

--- a/src/integrations/webhooks/base.py
+++ b/src/integrations/webhooks/base.py
@@ -57,6 +57,19 @@ class BaseWebhookProcessor:
             self._process_movie(payload, user, ids)
 
     def _process_tv(self, payload, user, ids):
+        anidb_id = ids.get("anidb_id")
+        if user.anime_enabled and anidb_id:
+            mapping_data = self._fetch_mapping_data()
+            matching_enty = mapping_data.get(anidb_id)
+            if not matching_enty:
+                return
+            episode_number = payload['Metadata']['index']
+            if not episode_number:
+                return
+            logger.info("Detected anime via AniDB ID: %s. Matching MAL ID: %s, Episode: %d", ids["anidb_id"], matching_enty["mal_id"], episode_number)
+            self._handle_anime(matching_enty["mal_id"], episode_number, payload, user)
+            return
+
         media_id, season_number, episode_number = self._find_tv_media_id(ids)
         if not media_id:
             logger.warning("No matching TMDB ID found for TV show")

--- a/src/integrations/webhooks/plex.py
+++ b/src/integrations/webhooks/plex.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 
 from app.models import MediaTypes
 
@@ -80,6 +81,7 @@ class PlexWebhookProcessor(BaseWebhookProcessor):
 
     def _extract_external_ids(self, payload):
         guids = payload["Metadata"].get("Guid", [])
+        guid = payload["Metadata"].get("guid", None)
 
         def get_id(prefix):
             return next(
@@ -91,8 +93,20 @@ class PlexWebhookProcessor(BaseWebhookProcessor):
                 None,
             )
 
+        def extract_hama_anidb_id(guid):
+            """
+            Extracts the AniDB ID from a Hama agent GUID string.
+            e.g., "com.plexapp.agents.hama://anidb-12834/1/2?lang=en" -> "12834"
+            """
+            if guid and "hama://anidb-" in guid:
+                match = re.search(r"anidb-(\d+)", guid)
+                if match:
+                    return match.group(1)
+            return None
+
         return {
             "tmdb_id": get_id("tmdb"),
             "imdb_id": get_id("imdb"),
             "tvdb_id": get_id("tvdb"),
+            "anidb_id": extract_hama_anidb_id(guid),
         }


### PR DESCRIPTION
# Context 
[HAMA agent](https://github.com/ZeroQI/Hama.bundle) and [Absolute Series Scanner](https://github.com/ZeroQI/Absolute-Series-Scanner) are common custom agents and scanners used in conjunction with Plex for anime. 

# Changes
This PR adds supports the HAMA plex agent for anime, by extracting the anidb id from the Plex file GUID and translating it to the matching MAL ID.  Also adds some tests to cover the changes. 

# Testing
Change was also tested manually by
1. Setting up a Plex server with HAMA and Absolute Series Scanner
2. Ingesting an anime series into plex using the new agent and scanner
3. Configuring the webhook in Yamtrack
4. Firing the webhook by playing/completing a series in plex. 