### PR TITLE
Hide media score if rating is 0

### DIFF
--- a/src/app/templatetags/app_tags.py
+++ b/src/app/templatetags/app_tags.py
@@ -388,3 +388,28 @@ def get_pagination_range(current_page, total_pages, window):
         result.append(total_pages)
 
     return result
+
+@register.filter
+def show_media_score(rating):
+    """
+    Return if we should show the rating of a media.
+
+    Args:
+        rating: the rating value of the media
+
+    Returns:
+        True if we should show the media score
+    """
+    return show_media_score(rating, settings.HIDE_ZERO_RATING)
+
+def show_media_score(rating, hide_zero_rating):  # noqa: F811
+    """
+    Return if we should show the rating of a media.
+
+    Args:
+        rating: the rating value of the media
+
+    Returns:
+        True if we should show the media score
+    """
+    return rating is not None and (not hide_zero_rating or (hide_zero_rating and rating > 0))  # noqa: E501

--- a/src/app/tests/test_templatetags.py
+++ b/src/app/tests/test_templatetags.py
@@ -360,3 +360,13 @@ class AppTagsTests(TestCase):
                 self.assertTrue(len(inactive_result) > 0)
             except KeyError:
                 self.fail(f"icon raised KeyError for {media_type}")
+
+    def test_show_media_score(self):
+        """Test if we should show media rating or not."""
+        self.assertTrue(app_tags.show_media_score(1, False))  # noqa: FBT003
+        self.assertTrue(app_tags.show_media_score(0, False))  # noqa: FBT003
+        self.assertFalse(app_tags.show_media_score(None, False))  # noqa: FBT003
+
+        self.assertTrue(app_tags.show_media_score(1, True))  # noqa: FBT003
+        self.assertFalse(app_tags.show_media_score(0, True))  # noqa: FBT003
+        self.assertFalse(app_tags.show_media_score(None, True))  # noqa: FBT003

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -452,6 +452,8 @@ SIMKL_SECRET = config(
     ),
 )
 
+HIDE_ZERO_RATING = config("HIDE_ZERO_RATING", default=False, cast=bool)
+
 TESTING = False
 
 HEALTHCHECK_CELERY_PING_TIMEOUT = config(

--- a/src/templates/app/components/media_card.html
+++ b/src/templates/app/components/media_card.html
@@ -46,7 +46,7 @@
       </div>
     {% endif %}
 
-    {% if media.score is not None %}
+    {% if media.score|show_media_score %}
       <div class="absolute {% if from_grid %}sm:top-2 sm:right-2 sm:left-auto{% endif %} top-10 left-2 bg-gray-900/90 text-white text-xs px-2 py-1 rounded-md flex items-center shadow-md">
         {% include "app/icons/star.svg" with classes="w-4 h-4 text-yellow-400 mr-1 fill-current" %}
         <span class="text-sm text-white">{{ media.formatted_score }}</span>

--- a/src/templates/app/statistics.html
+++ b/src/templates/app/statistics.html
@@ -379,7 +379,7 @@
                               {% if media.end_date %}{{ media.end_date|date_tracker_format }}{% endif %}
                             </p>
                           </div>
-                          {% if media.score is not None %}
+                          {% if media.score|show_media_score %}
                             <div class="flex items-center text-sm text-yellow-400 mt-2">
                               {% include "app/icons/star.svg" with classes="w-4 h-4 mr-1 fill-current" %}
                               <span>{{ media.formatted_score }}</span>


### PR DESCRIPTION
Sometimes the media items have 0 ratings, which looks strange in my opinion. But it could be used as a feature as well, for example if someone wants to rate something later, then it can be used to indicate that intent. So, in order to not break that workflow, I created an environment variable to hide the 0 rating from the UI.
Usage: set HIDE_ZERO_RATING environment variable to 'True'