### PR TITLE
Remove conflict of migrations: Move one further down in the chain

### DIFF
--- a/src/users/migrations/0040_user_list_detail_status_alter_user_home_sort_and_more.py
+++ b/src/users/migrations/0040_user_list_detail_status_alter_user_home_sort_and_more.py
@@ -9,6 +9,7 @@ class Migration(migrations.Migration):
         ('app', '0051_migrate_simkl_periodoc_tasks'),
         ('auth', '0012_alter_user_first_name_max_length'),
         ('users', '0037_remove_user_home_sort_valid_alter_user_home_sort'),
+        ('users', '0039_user_clickable_media_cards'),
     ]
 
     operations = [


### PR DESCRIPTION
Without it this currently results in an error at startup on a fresh checkout, e.g. when just doing `docker compose up`:

    yamtrack        | CommandError: Conflicting migrations detected; multiple leaf nodes in the migration graph: (0038_user_list_detail_status_alter_user_home_sort_and_more, 0039_user_clickable_media_cards in users).
    yamtrack        | To fix them run 'python manage.py makemigrations --merge'
    yamtrack exited with code 1 (restarting)

`0038_user_list_detail_status_alter_user_home_sort_and_more` was added in #928, but by the time it was merged another migration had already been added as well.