### PR TITLE
Fix duplicate home_sort_valid constraint in migration

### DIFF
--- a/src/users/migrations/0043_add_boardgame_preferences.py
+++ b/src/users/migrations/0043_add_boardgame_preferences.py
@@ -50,8 +50,4 @@ class Migration(migrations.Migration):
             model_name='user',
             constraint=models.CheckConstraint(condition=models.Q(('last_search_type__in', ['tv', 'movie', 'anime', 'manga', 'game', 'book', 'comic', 'boardgame'])), name='last_search_type_valid'),
         ),
-        migrations.AddConstraint(
-            model_name='user',
-            constraint=models.CheckConstraint(condition=models.Q(('home_sort__in', ['upcoming', 'recent', 'completion', 'episodes_left', 'title'])), name='home_sort_valid'),
-        ),
     ]


### PR DESCRIPTION
## Summary
Fixes #1131 - Container fails to start due to faulty migration

## Problem
The `home_sort_valid` constraint was being added twice:
1. In migration `0038_alter_user_home_sort_user_home_sort_valid`
2. Again in migration `0043_add_boardgame_preferences`

This caused a `ProgrammingError: constraint "home_sort_valid" for relation "users_user" already exists` when running migrations.

## Solution
Removed the duplicate `AddConstraint` operation for `home_sort_valid` from `0043_add_boardgame_preferences.py` since the constraint is already properly created by migration `0038`.