### PR TITLE
Support providing playtime as float

### DIFF
--- a/src/app/forms.py
+++ b/src/app/forms.py
@@ -92,7 +92,7 @@ class CustomDurationField(forms.CharField):
             self._validate_minutes(minutes)
             return hours * 60 + minutes
         except ValueError as e:
-            msg = "Invalid time played format. Please use hours (integer), hours (float), hh:mm, [n]h [n]min or [n]h[n]min format."  # noqa: E501
+            msg = "Invalid time format. Provide duration in hours (e.g., '5', '1.5'), hours and minutes (e.g., '5:30', '5h 30min'), or just minutes (e.g., '30min')."  # noqa: E501
             raise forms.ValidationError(msg) from e
 
 

--- a/src/app/forms.py
+++ b/src/app/forms.py
@@ -47,9 +47,11 @@ class CustomDurationField(forms.CharField):
 
         try: # hours and minutes as float
             converted_to_float = float(value)
+            if not math.isfinite(converted_to_float):
+                raise ValueError("Value must be finite")
             hour_parts, hours = math.modf(converted_to_float)
             return int(hours), int(hour_parts * 60)
-        except ValueError:
+        except (ValueError, OverflowError):
             pass
 
         if ":" in value:  # hh:mm format

--- a/src/app/forms.py
+++ b/src/app/forms.py
@@ -1,6 +1,8 @@
 from django import forms
 from django.conf import settings
 
+import math
+
 from app import config
 from app.models import (
     TV,
@@ -33,6 +35,7 @@ class CustomDurationField(forms.CharField):
 
         Supported formats:
         - Plain number (hours only): "5"
+        - Plain float number (hours and minutes): "1.5"
         - HH:MM: "5:30"
         - Nh Nmin: "5h 30min"
         - NhNmin: "5h30min"
@@ -41,6 +44,13 @@ class CustomDurationField(forms.CharField):
         """
         if value.isdigit():  # hours only
             return int(value), 0
+
+        try: # hours and minutes as float
+            converted_to_float = float(value)
+            hour_parts, hours = math.modf(converted_to_float)
+            return int(hours), int(hour_parts * 60)
+        except ValueError:
+            pass
 
         if ":" in value:  # hh:mm format
             hours, minutes = value.split(":")
@@ -80,7 +90,7 @@ class CustomDurationField(forms.CharField):
             self._validate_minutes(minutes)
             return hours * 60 + minutes
         except ValueError as e:
-            msg = "Invalid time played format. Please use hh:mm, [n]h [n]min or [n]h[n]min format."  # noqa: E501
+            msg = "Invalid time played format. Please use hours (integer), hours (float), hh:mm, [n]h [n]min or [n]h[n]min format."  # noqa: E501
             raise forms.ValidationError(msg) from e
 
 

--- a/src/app/tests/test_forms.py
+++ b/src/app/tests/test_forms.py
@@ -188,6 +188,20 @@ class BasicGameForm(TestCase):
         form = GameForm(data=form_data)
         self.assertTrue(form.is_valid())
 
+    def test_fifth_alternate_progress(self):
+        """Test the game form using a fifth alternate progress format."""
+        form_data = {
+            "media_id": "1",
+            "source": Sources.IGDB.value,
+            "media_type": MediaTypes.GAME.value,
+            "user": self.user.id,
+            "status": Status.COMPLETED.value,
+            "progress": "1.5",
+            "repeats": 0,
+        }
+        form = GameForm(data=form_data)
+        self.assertTrue(form.is_valid())
+
     def test_invalid_progress(self):
         """Test the game form using an invalid default progress format."""
         form_data = {


### PR DESCRIPTION
Currently the playtime can be provided with a single number of hours as integer but I find myself often only knowing the total playtime as float (e.g. Steam only provides this number in the app's UI), for example 3.5 to signify 3 hours 30 minutes.

Supporting this float notation is very easy and works well with the established system. I have also changed the error message to include more information on what's allowed though it's getting a bit unwieldy.