### PR TITLE
feat: add SESSION_COOKIE_AGE environment variable

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -607,3 +607,5 @@ if not REGISTRATION:
     ACCOUNT_ADAPTER = "users.account_adapter.NoNewUsersAccountAdapter"
 
 REDIRECT_LOGIN_TO_SSO = config("REDIRECT_LOGIN_TO_SSO", default=False, cast=bool)
+
+SESSION_COOKIE_AGE = config("SESSION_COOKIE_AGE", default=1209600, cast=int)

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -608,4 +608,4 @@ if not REGISTRATION:
 
 REDIRECT_LOGIN_TO_SSO = config("REDIRECT_LOGIN_TO_SSO", default=False, cast=bool)
 
-SESSION_COOKIE_AGE = config("SESSION_COOKIE_AGE", default=1209600, cast=int)
+SESSION_COOKIE_AGE = config("SESSION_COOKIE_AGE", default=60 * 60 * 24 * 14, cast=int)


### PR DESCRIPTION
Add `SESSION_COOKIE_AGE` environment variable to allow adjustment of session cookie expiration date (see: https://docs.djangoproject.com/en/dev/ref/settings/#session-cookie-age)

Closes/Resolves #1185 

(Thanks @FuzzyGrim for pointing me to the solution :wink: )