### PR TITLE
Make all metadata titles uppercase

### DIFF
--- a/src/templates/app/media_details.html
+++ b/src/templates/app/media_details.html
@@ -448,7 +448,7 @@
             </div>
           {% endfor %}
           <div>
-            <h3 class="text-sm font-semibold text-gray-400">Source</h3>
+            <h3 class="text-sm font-semibold text-gray-400">SOURCE</h3>
             <a href="{{ media.source_url }}"
                class="text-gray-200 hover:text-indigo-500 transition-colors duration-200"
                target="_blank">{{ media.source|source_readable }}</a>


### PR DESCRIPTION
The only title in the details section that was not upper case was the "source" title.

This PR makes that uppercase, to satisfy my OCD =) 

| Before | After |
|--------|--------|
| <img width="271" height="543" alt="image" src="https://github.com/user-attachments/assets/74d21e8b-71ff-4317-93ad-f0c0ccc1e305" /> | <img width="271" height="543" alt="image" src="https://github.com/user-attachments/assets/336864e9-02f5-4512-9ca1-6f9676c29b33" /> | 