### PR TITLE
Fix TV webhook failing when IMDB/TVDB returns series-level match

### DIFF
--- a/src/integrations/webhooks/base.py
+++ b/src/integrations/webhooks/base.py
@@ -172,7 +172,7 @@ class BaseWebhookProcessor:
                 if response.get("tv_results"):
                     return response["tv_results"][0].get("id"), None, None
         return None, None, None
-        
+
     def _fetch_mapping_data(self):
         """Fetch anime mapping data with caching."""
         data = cache.get("anime_mapping_data")

--- a/src/integrations/webhooks/base.py
+++ b/src/integrations/webhooks/base.py
@@ -55,13 +55,21 @@ class BaseWebhookProcessor:
             self._process_tv(payload, user, ids)
         elif media_type == MediaTypes.MOVIE.value:
             self._process_movie(payload, user, ids)
-
+            
     def _process_tv(self, payload, user, ids):
         media_id, season_number, episode_number = self._find_tv_media_id(ids)
         if not media_id:
             logger.warning("No matching TMDB ID found for TV show")
             return
-
+        if season_number is None: # If season/episode weren't resolved from TMDB (series-level ID was used), fall back to the values sent directly in the webhook payload
+            season_number = payload["Item"].get("ParentIndexNumber")
+        if episode_number is None:
+            episode_number = payload["Item"].get("IndexNumber")
+        if season_number is None or episode_number is None:
+            logger.warning(
+                "Could not determine season/episode number for TMDB ID: %s", media_id
+            )
+            return
         tvdb_id = app.providers.tmdb.tv_with_seasons(media_id, [season_number])[
             "tvdb_id"
         ]
@@ -150,14 +158,18 @@ class BaseWebhookProcessor:
         ]:
             if ext_id:
                 response = app.providers.tmdb.find(ext_id, ext_type)
-                if response.get("tv_episode_results"):
+                if response.get("tv_episode_results"): # Episode-level ID: TMDB returns season+episode directly
                     result = response["tv_episode_results"][0]
                     return (
                         result.get("show_id"),
                         result.get("season_number"),
                         result.get("episode_number"),
                     )
+                if response.get("tv_results"): # Series-level ID: TMDB returns the show but not the episode, Season/episode will be taken from the webhook payload instead
+                    return response["tv_results"][0].get("id"), None, None
+                
         return None, None, None
+
 
     def _fetch_mapping_data(self):
         """Fetch anime mapping data with caching."""

--- a/src/integrations/webhooks/base.py
+++ b/src/integrations/webhooks/base.py
@@ -55,13 +55,14 @@ class BaseWebhookProcessor:
             self._process_tv(payload, user, ids)
         elif media_type == MediaTypes.MOVIE.value:
             self._process_movie(payload, user, ids)
-            
+
     def _process_tv(self, payload, user, ids):
         media_id, season_number, episode_number = self._find_tv_media_id(ids)
         if not media_id:
             logger.warning("No matching TMDB ID found for TV show")
             return
-        if season_number is None: # If season/episode weren't resolved from TMDB (series-level ID was used), fall back to the values sent directly in the webhook payload
+        # fall back to webhook payload if season/episode weren't resolved from TMDB
+        if season_number is None:
             season_number = payload["Item"].get("ParentIndexNumber")
         if episode_number is None:
             episode_number = payload["Item"].get("IndexNumber")
@@ -158,19 +159,20 @@ class BaseWebhookProcessor:
         ]:
             if ext_id:
                 response = app.providers.tmdb.find(ext_id, ext_type)
-                if response.get("tv_episode_results"): # Episode-level ID: TMDB returns season+episode directly
+                # Episode-level ID: TMDB returns season+episode directly
+                if response.get("tv_episode_results"):
                     result = response["tv_episode_results"][0]
                     return (
                         result.get("show_id"),
                         result.get("season_number"),
                         result.get("episode_number"),
                     )
-                if response.get("tv_results"): # Series-level ID: TMDB returns the show but not the episode, Season/episode will be taken from the webhook payload instead
+                # If TMDB returns show but episode
+                # Season/episode will be taken from the webhook payload
+                if response.get("tv_results"):
                     return response["tv_results"][0].get("id"), None, None
-                
         return None, None, None
-
-
+        
     def _fetch_mapping_data(self):
         """Fetch anime mapping data with caching."""
         data = cache.get("anime_mapping_data")


### PR DESCRIPTION
Was trying to use Yamtrack to track content on apps outside of the usual JF/Plex/Emby via webhook. But currently it fails to add a new show to yamtrack if series-level metadata ID is returned.

## What
Currently `_find_tv_media_id` in `base.py` only checked `tv_episode_results` from the TMDB `/find` endpoint.

## Why
When a webhook payload contains a series-level IMDB or TVDB ID, TMDB returns the show under `tv_results` instead of `tv_episode_results`. This caused `_find_tv_media_id` to always return `(None, None, None)`, logging "No matching TMDB ID found for TV show" and silently dropping the webhook without tracking anything.

## How
Also check `tv_results` as a fallback. When a series-level match is found, season and episode numbers are not available from the TMDB response and are returned as `None`. They are then read from the webhook payload's `ParentIndexNumber` and `IndexNumber` fields, which was already the existing behaviour in `_process_tv` for this case.

## Files changed
- `app/integrations/webhooks/base.py`
