### PR TITLE
Fix time format not respecting user preference

### DIFF
--- a/src/app/views.py
+++ b/src/app/views.py
@@ -785,6 +785,7 @@ def history_modal(
             "timeline": timeline_entries,
             "total_medias": total_medias,
             "return_url": request.GET["return_url"],
+            "user": request.user,
         },
     )
 
@@ -881,6 +882,7 @@ def statistics(request):
         "status_distribution": status_distribution,
         "status_pie_chart_data": status_pie_chart_data,
         "timeline": timeline,
+        "user": request.user,
     }
 
     return render(request, "app/statistics.html", context)

--- a/src/events/views.py
+++ b/src/events/views.py
@@ -90,6 +90,7 @@ def calendar(request):
         "release_dict": release_dict,
         "today": today,
         "view_type": view_type,
+        "user": request.user,
     }
     return render(request, "events/calendar.html", context)
 

--- a/src/templates/app/media_details.html
+++ b/src/templates/app/media_details.html
@@ -256,14 +256,14 @@
               {% if current_instance.start_date %}
                 <div class="flex @max-[210px]:flex-col justify-between text-sm">
                   <span class="text-gray-400">Started:</span>
-                  <span class="text-gray-200">{{ current_instance.start_date|datetime_format:user }}</span>
+                  <span class="text-gray-200">{{ current_instance.start_date|datetime_format:request.user }}</span>
                 </div>
               {% endif %}
 
               {% if current_instance.end_date %}
                 <div class="flex @max-[210px]:flex-col justify-between text-sm">
                   <span class="text-gray-400">Ended:</span>
-                  <span class="text-gray-200">{{ current_instance.end_date|datetime_format:user }}</span>
+                  <span class="text-gray-200">{{ current_instance.end_date|datetime_format:request.user }}</span>
                 </div>
               {% endif %}
 
@@ -339,11 +339,11 @@
                       {% endif %}
 
                       {% if user_media.start_date %}
-                        <div class="text-xs text-gray-400">Started: {{ user_media.start_date|datetime_format:user }}</div>
+                        <div class="text-xs text-gray-400">Started: {{ user_media.start_date|datetime_format:request.user }}</div>
                       {% endif %}
 
                       {% if user_media.end_date %}
-                        <div class="text-xs text-gray-400">Finished: {{ user_media.end_date|datetime_format:user }}</div>
+                        <div class="text-xs text-gray-400">Finished: {{ user_media.end_date|datetime_format:request.user }}</div>
                       {% endif %}
 
                       {% if user_media.notes %}
@@ -622,7 +622,7 @@
                     </div>
                     {% if episode.history %}
                       <p class="text-xs text-gray-400 mt-2 px-4">
-                        Last watched: {{ episode.history.0.end_date|datetime_format:user }}
+                        Last watched: {{ episode.history.0.end_date|datetime_format:request.user }}
                         {% if not episode.history.0.end_date %}No date provided{% endif %}
                         {% if episode.history|length > 1 %}• Watched {{ episode.history|length }} times{% endif %}
                       </p>

--- a/src/templates/app/statistics.html
+++ b/src/templates/app/statistics.html
@@ -374,9 +374,9 @@
                           </h4>
                           <div class="text-sm text-gray-400 mt-1">
                             <p>
-                              {% if media.start_date %}{{ media.start_date|datetime_format:user }}{% endif %}
+                              {% if media.start_date %}{{ media.start_date|datetime_format:request.user }}{% endif %}
                               {% if media.start_date and media.end_date %}-{% endif %}
-                              {% if media.end_date %}{{ media.end_date|datetime_format:user }}{% endif %}
+                              {% if media.end_date %}{{ media.end_date|datetime_format:request.user }}{% endif %}
                             </p>
                           </div>
                           {% if media.score|show_media_score:user %}

--- a/src/users/views.py
+++ b/src/users/views.py
@@ -286,7 +286,7 @@ def integrations(request):
 def import_data(request):
     """Render the import data settings page."""
     import_tasks = request.user.get_import_tasks()
-    return render(request, "users/import_data.html", {"import_tasks": import_tasks})
+    return render(request, "users/import_data.html", {"import_tasks": import_tasks, "user": request.user})
 
 
 @require_GET


### PR DESCRIPTION
## Summary
- Fixes bug where 12h time format was used despite 24h format being configured in user preferences
- The `datetime_format` and `time_format` template filters require the user object to be passed in the template context
- Several views were missing this, causing the template filter to fall back to a default format

### Changes Made
- Added `'user': request.user` to context in views that were missing it (statistics, fill_history, calendar, import_data)
- Changed `user` to `request.user` in templates where the request object is available (media_details, statistics)

### Files Changed
- `src/app/views.py`
- `src/events/views.py`  
- `src/users/views.py`
- `src/templates/app/media_details.html`
- `src/templates/app/statistics.html`

Fixes #1259