### PR TITLE
Fix Incremental sync with trakt 

### DIFF
--- a/src/integrations/imports/helpers.py
+++ b/src/integrations/imports/helpers.py
@@ -11,12 +11,28 @@ from django.conf import settings
 from django.contrib import messages
 from django.utils import timezone
 from django_celery_beat.models import CrontabSchedule, PeriodicTask
-from simple_history.utils import bulk_create_with_history
+from simple_history.utils import bulk_create_with_history, bulk_update_with_history
 
 import app
-from app.models import MediaTypes
+from app.models import MediaTypes, Sources
 
 logger = logging.getLogger(__name__)
+
+
+def get_last_import_date(user, task_name):
+    """Return date_done of the most recent successful import task, or None."""
+    from django_celery_results.models import TaskResult
+
+    result = (
+        TaskResult.objects.filter(
+            task_name=task_name,
+            task_kwargs__contains=f"'user_id': {user.id},",
+            status="SUCCESS",
+        )
+        .order_by("-date_done")
+        .first()
+    )
+    return result.date_done.date() if result else None
 
 
 class MediaImportError(Exception):
@@ -182,12 +198,38 @@ def bulk_create_media(bulk_media_list, user):
             )
             update_episode_references(bulk_media, user)
 
+        ignore_conflicts = media_type != MediaTypes.EPISODE.value
         bulk_create_with_history(
             bulk_media,
             model,
             batch_size=500,
             default_user=user,
+            ignore_conflicts=ignore_conflicts,
         )
+
+
+def update_rewatched_movies(movie_objs, existing_media, user):
+    """Update end_date for movies that already existed (rewatches)."""
+    existing_ids = existing_media[MediaTypes.MOVIE.value][Sources.TMDB.value]
+    updates = {}
+    for movie_obj in movie_objs:
+        tmdb_id = movie_obj.item.media_id
+        if tmdb_id in existing_ids:
+            if tmdb_id not in updates or movie_obj.end_date > updates[tmdb_id]:
+                updates[tmdb_id] = movie_obj.end_date
+    if not updates:
+        return
+    Movie = apps.get_model("app", "movie")
+    movies_to_update = list(
+        Movie.objects.filter(
+            user=user,
+            item__media_id__in=updates.keys(),
+            item__source=Sources.TMDB.value,
+        ).select_related("item")
+    )
+    for movie in movies_to_update:
+        movie.end_date = updates[movie.item.media_id]
+    bulk_update_with_history(movies_to_update, Movie, ["end_date"], default_user=user)
 
 
 def create_import_schedule(

--- a/src/integrations/imports/trakt.py
+++ b/src/integrations/imports/trakt.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 from collections import defaultdict
@@ -166,6 +167,12 @@ class TraktImporter:
         # Track existing media to handle "new" mode correctly
         self.existing_media = helpers.get_existing_media(user)
 
+        # Last successful import date for incremental sync
+        self.last_import_at = helpers.get_last_import_date(user, "Import from Trakt")
+
+        # Pre-load existing episode watches for dedup during the overlap window
+        self.existing_episode_watch_keys = self._load_existing_episode_watch_keys()
+
         # Track media IDs to delete in overwrite mode
         self.to_delete = defaultdict(lambda: defaultdict(set))
 
@@ -181,6 +188,26 @@ class TraktImporter:
             mode,
         )
 
+    def _load_existing_episode_watch_keys(self):
+        """Load (media_id, season_number, episode_number, end_date) tuples for
+        episodes in the overlap window to prevent duplicate creation."""
+        if not (self.mode == "new" and self.last_import_at):
+            return set()
+        since = self.last_import_at - datetime.timedelta(days=1)
+        until = self.last_import_at + datetime.timedelta(days=1)
+        return set(
+            app.models.Episode.objects.filter(
+                related_season__user=self.user,
+                end_date__date__gte=since,
+                end_date__date__lte=until,
+            ).values_list(
+                "item__media_id",
+                "item__season_number",
+                "item__episode_number",
+                "end_date",
+            )
+        )
+
     def import_data(self):
         """Import all user data from Trakt."""
         self.process_history()
@@ -190,6 +217,11 @@ class TraktImporter:
 
         helpers.cleanup_existing_media(self.to_delete, self.user)
         helpers.bulk_create_media(self.bulk_media, self.user)
+        helpers.update_rewatched_movies(
+            self.bulk_media[MediaTypes.MOVIE.value],
+            self.existing_media,
+            self.user,
+        )
 
         imported_counts = {
             media_type: len(media_list)
@@ -220,13 +252,15 @@ class TraktImporter:
             headers=headers,
         )
 
-    def _get_paginated_data(self, endpoint, item_type="items"):
+    def _get_paginated_data(self, endpoint, item_type="items", start_at=None):
         """Get paginated data from Trakt API."""
         page = 1
         all_data = []
 
         while True:
             url = f"{endpoint}?page={page}&limit={BULK_PAGE_SIZE}"
+            if start_at:
+                url += f"&start_at={start_at.isoformat()}"
 
             try:
                 page_data = self._make_api_request(url)
@@ -269,7 +303,14 @@ class TraktImporter:
         """Process watch history from Trakt."""
         logger.info("Importing watch history for user %s", self.username)
         history_endpoint = f"{self.user_base_url}/history"
-        full_history = self._get_paginated_data(history_endpoint, "history entries")
+        start_at = (
+            self.last_import_at - datetime.timedelta(days=1)
+            if self.mode == "new" and self.last_import_at
+            else None
+        )
+        full_history = self._get_paginated_data(
+            history_endpoint, "history entries", start_at=start_at
+        )
 
         # Process in chronological order (oldest first)
         for entry in reversed(full_history):
@@ -372,16 +413,17 @@ class TraktImporter:
         if not tmdb_id:
             return
 
-        # Check if we should process this movie based on mode
-        if not helpers.should_process_media(
-            self.existing_media,
-            self.to_delete,
-            MediaTypes.MOVIE.value,
-            Sources.TMDB.value,
-            tmdb_id,
-            self.mode,
-        ):
-            return
+        # Skip existence check when date-based filtering guarantees all entries are new
+        if not (self.mode == "new" and self.last_import_at):
+            if not helpers.should_process_media(
+                self.existing_media,
+                self.to_delete,
+                MediaTypes.MOVIE.value,
+                Sources.TMDB.value,
+                tmdb_id,
+                self.mode,
+            ):
+                return
 
         metadata = self._get_metadata(MediaTypes.MOVIE.value, tmdb_id, movie["title"])
         if not metadata:
@@ -420,16 +462,17 @@ class TraktImporter:
         if not tmdb_id:
             return
 
-        # Check if we should process this episode based on mode
-        if not helpers.should_process_media(
-            self.existing_media,
-            self.to_delete,
-            MediaTypes.TV.value,
-            Sources.TMDB.value,
-            tmdb_id,
-            self.mode,
-        ):
-            return
+        # Skip existence check when date-based filtering guarantees all entries are new
+        if not (self.mode == "new" and self.last_import_at):
+            if not helpers.should_process_media(
+                self.existing_media,
+                self.to_delete,
+                MediaTypes.TV.value,
+                Sources.TMDB.value,
+                tmdb_id,
+                self.mode,
+            ):
+                return
 
         # Extract episode data
         season_number = entry["episode"]["season"]
@@ -516,6 +559,11 @@ class TraktImporter:
             season_number,
             episode_number,
         )
+
+        # Dedup: skip if this exact watch already exists (overlap window)
+        ep_watch_key = (tmdb_id, season_number, episode_number, parse_datetime(watched_at))
+        if ep_watch_key in self.existing_episode_watch_keys:
+            return
 
         ep_key = f"{tmdb_id}:{season_number}:{episode_number}"
 

--- a/src/integrations/tests/imports/test_trakt.py
+++ b/src/integrations/tests/imports/test_trakt.py
@@ -1,3 +1,4 @@
+import datetime
 from pathlib import Path
 from unittest.mock import patch
 
@@ -273,3 +274,130 @@ class ImportTrakt(TestCase):
         self.assertEqual(importer.username, "testuser")
         self.assertIsNone(importer.refresh_token)
         self.assertEqual(importer.mode, "new")
+
+    @patch("integrations.imports.trakt.TraktImporter._get_metadata")
+    def test_new_mode_imports_episodes_for_existing_show(self, mock_get_metadata):
+        """Episodes for an existing show should be imported in new mode with last_import_at."""
+        episode_entry = {
+            "type": "episode",
+            "episode": {"season": 1, "number": 2, "title": "Second Episode"},
+            "show": {"title": "Existing Show", "ids": {"tmdb": 99999}},
+            "watched_at": "2026-03-15T00:00:00.000Z",
+        }
+
+        def mock_metadata_side_effect(media_type, _, __, ___=None):
+            if media_type == MediaTypes.TV.value:
+                return {
+                    "title": "Existing Show",
+                    "image": "tv_image.jpg",
+                    "last_episode_season": 1,
+                    "max_progress": 5,
+                }
+            if media_type == MediaTypes.SEASON.value:
+                return {
+                    "title": "Season 1",
+                    "image": "season_image.jpg",
+                    "episodes": [
+                        {"episode_number": 1, "still_path": None},
+                        {"episode_number": 2, "still_path": "/ep2.jpg"},
+                    ],
+                    "max_progress": 5,
+                }
+            return None
+
+        mock_get_metadata.side_effect = mock_metadata_side_effect
+
+        trakt_importer = TraktImporter("testuser", self.user, "new")
+        # Simulate that the show already exists in the DB
+        trakt_importer.existing_media[MediaTypes.TV.value]["tmdb"]["99999"] = object()
+        # Simulate that a previous import was done (use a date far enough back
+        # that the watched_at timestamp is outside the dedup window)
+        trakt_importer.last_import_at = datetime.date(2026, 3, 7)
+        trakt_importer.existing_episode_watch_keys = set()
+
+        trakt_importer.process_watched_episode(episode_entry)
+
+        # Episode must be added despite the show already existing
+        self.assertEqual(len(trakt_importer.bulk_media[MediaTypes.EPISODE.value]), 1)
+
+    @patch("integrations.imports.trakt.TraktImporter._make_api_request")
+    def test_start_at_appended_when_last_import_exists(self, mock_make_request):
+        """start_at in URL should be last_import_at minus 1 day."""
+        mock_make_request.return_value = []
+
+        # last_import_at is a date object; start_at should be last_import_at - 1 day
+        trakt_importer = TraktImporter("testuser", self.user, "new")
+        trakt_importer.last_import_at = datetime.date(2026, 3, 1)
+
+        trakt_importer.process_history()
+
+        urls_called = [call.args[0] for call in mock_make_request.call_args_list]
+        self.assertTrue(
+            any("start_at=" in url for url in urls_called),
+            f"Expected start_at in URL, got: {urls_called}",
+        )
+        # start_at should be 2026-02-28 (one day before last_import_at)
+        self.assertTrue(
+            any("2026-02-28" in url for url in urls_called),
+            f"Expected 2026-02-28 in URL, got: {urls_called}",
+        )
+
+    @patch("integrations.imports.trakt.TraktImporter._make_api_request")
+    def test_no_start_at_on_first_import(self, mock_make_request):
+        """start_at should not be appended when there is no previous import."""
+        mock_make_request.return_value = []
+
+        trakt_importer = TraktImporter("testuser", self.user, "new")
+        trakt_importer.last_import_at = None
+
+        trakt_importer.process_history()
+
+        urls_called = [call.args[0] for call in mock_make_request.call_args_list]
+        self.assertFalse(
+            any("start_at=" in url for url in urls_called),
+            f"Expected no start_at in URL, got: {urls_called}",
+        )
+
+    @patch("integrations.imports.trakt.TraktImporter._get_metadata")
+    def test_episode_dedup_skips_existing_watch(self, mock_get_metadata):
+        """An episode watch already in existing_episode_watch_keys should be skipped."""
+        watched_at = "2026-03-01T10:00:00.000Z"
+        episode_entry = {
+            "type": "episode",
+            "episode": {"season": 1, "number": 1, "title": "Pilot"},
+            "show": {"title": "Test Show", "ids": {"tmdb": 11111}},
+            "watched_at": watched_at,
+        }
+
+        def mock_metadata_side_effect(media_type, _, __, ___=None):
+            if media_type == MediaTypes.TV.value:
+                return {
+                    "title": "Test Show",
+                    "image": "tv.jpg",
+                    "last_episode_season": 1,
+                    "max_progress": 1,
+                }
+            if media_type == MediaTypes.SEASON.value:
+                return {
+                    "title": "Season 1",
+                    "image": "s1.jpg",
+                    "episodes": [{"episode_number": 1, "still_path": None}],
+                    "max_progress": 1,
+                }
+            return None
+
+        mock_get_metadata.side_effect = mock_metadata_side_effect
+
+        from django.utils.dateparse import parse_datetime
+
+        trakt_importer = TraktImporter("testuser", self.user, "new")
+        trakt_importer.last_import_at = datetime.date(2026, 3, 2)
+        # Pre-populate dedup set with the exact watch key
+        trakt_importer.existing_episode_watch_keys = {
+            ("11111", 1, 1, parse_datetime(watched_at)),
+        }
+
+        trakt_importer.process_watched_episode(episode_entry)
+
+        # Episode should be skipped — already in the dedup set
+        self.assertEqual(len(trakt_importer.bulk_media[MediaTypes.EPISODE.value]), 0)


### PR DESCRIPTION
Currently incremental sync with trakt, gets all the data from trakt again, which is hugely wasteful. We get only the data from the last time the sync happened. 
Also update the episodes of shows that were watched / rewatched. 
Movies rewatch to also fix.
Fixes #655 