### PR TITLE
feat: add Plex media.rate event support for rating sync

### DIFF
--- a/src/integrations/tests/test_webhooks_plex.py
+++ b/src/integrations/tests/test_webhooks_plex.py
@@ -675,17 +675,15 @@ class PlexWebhookTests(TestCase):
 
     def test_get_rating(self):
         """Test extraction of rating from payload."""
-        payload_with_rating = {
-            "Metadata": {"userRating": 8}
-        }
+        payload_with_rating = {"Metadata": {"userRating": 8}}
         payload_without_rating = {"Metadata": {"userRating": None}}
         payload_no_field = {"Metadata": {}}
 
         processor = PlexWebhookProcessor()
 
-        self.assertEqual(processor._get_rating(payload_with_rating), 8.0)
-        self.assertIsNone(processor._get_rating(payload_without_rating))
-        self.assertIsNone(processor._get_rating(payload_no_field))
+        self.assertEqual(processor._get_rating_from_payload(payload_with_rating), 8.0)
+        self.assertIsNone(processor._get_rating_from_payload(payload_without_rating))
+        self.assertIsNone(processor._get_rating_from_payload(payload_no_field))
 
     def test_is_rating_event(self):
         """Test detection of rating events."""

--- a/src/integrations/tests/test_webhooks_plex.py
+++ b/src/integrations/tests/test_webhooks_plex.py
@@ -470,3 +470,546 @@ class PlexWebhookTests(TestCase):
             "anidb_id": None,
         }
         self.assertEqual(result, expected)
+
+    def test_movie_rating(self):
+        """Test webhook handles movie rating event."""
+        movie_item = Item.objects.create(
+            media_id="603",
+            source="tmdb",
+            media_type=MediaTypes.MOVIE.value,
+            title="The Matrix",
+            image="https://example.com/matrix.jpg",
+        )
+        Movie.objects.create(
+            item=movie_item,
+            user=self.user,
+            progress=1,
+            status=Status.COMPLETED.value,
+            score=None,
+        )
+
+        payload = {
+            "event": "media.rate",
+            "Account": {
+                "title": "testuser",
+            },
+            "Metadata": {
+                "type": "movie",
+                "title": "The Matrix",
+                "userRating": 9,
+                "Guid": [
+                    {
+                        "id": "imdb://tt0133093",
+                    },
+                    {
+                        "id": "tmdb://603",
+                    },
+                ],
+            },
+        }
+
+        data = {"payload": json.dumps(payload)}
+
+        response = self.client.post(
+            self.url,
+            data=data,
+            format="multipart",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        movie = Movie.objects.get(item__media_id="603", user=self.user)
+        self.assertEqual(movie.score, 9.0)
+
+    def test_tv_rating(self):
+        """Test webhook handles TV show rating event."""
+        tv_item = Item.objects.create(
+            media_id="1668",
+            source="tmdb",
+            media_type=MediaTypes.TV.value,
+            title="Friends",
+            image="https://example.com/friends.jpg",
+        )
+        TV.objects.create(
+            item=tv_item,
+            user=self.user,
+            progress=1,
+            status=Status.COMPLETED.value,
+            score=None,
+        )
+
+        payload = {
+            "event": "media.rate",
+            "Account": {"title": "testuser"},
+            "Metadata": {
+                "type": "show",
+                "title": "Friends",
+                "userRating": 8,
+                "Guid": [{"id": "tmdb://1668"}, {"id": "tvdb://10097"}],
+            },
+        }
+
+        data = {"payload": json.dumps(payload)}
+
+        response = self.client.post(
+            self.url,
+            data=data,
+            format="multipart",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        tv = TV.objects.get(item__media_id="1668", user=self.user)
+        self.assertEqual(tv.score, 8.0)
+
+    def test_anime_rating(self):
+        """Test webhook handles anime rating event."""
+        anime_item = Item.objects.create(
+            media_id="437",
+            source="mal",
+            media_type=MediaTypes.ANIME.value,
+            title="Perfect Blue",
+            image="https://example.com/perfectblue.jpg",
+        )
+        Anime.objects.create(
+            item=anime_item,
+            user=self.user,
+            progress=1,
+            status=Status.COMPLETED.value,
+            score=None,
+        )
+
+        payload = {
+            "event": "media.rate",
+            "Account": {"title": "testuser"},
+            "Metadata": {
+                "type": "movie",
+                "title": "Perfect Blue",
+                "userRating": 10,
+                "Guid": [
+                    {"id": "tmdb://10494"},
+                    {"id": "imdb://tt0156887"},
+                ],
+            },
+        }
+
+        data = {"payload": json.dumps(payload)}
+
+        response = self.client.post(
+            self.url,
+            data=data,
+            format="multipart",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # Verify rating was saved
+        anime = Anime.objects.get(item__media_id="437", user=self.user)
+        self.assertEqual(anime.score, 10.0)
+
+    def test_rating_untracked_media(self):
+        """Test rating media that is not in user's list - should log but not create."""
+        payload = {
+            "event": "media.rate",
+            "Account": {"title": "testuser"},
+            "Metadata": {
+                "type": "movie",
+                "title": "Unknown Movie",
+                "userRating": 7,
+                "Guid": [{"id": "tmdb://99999999"}],
+            },
+        }
+
+        data = {"payload": json.dumps(payload)}
+
+        response = self.client.post(
+            self.url,
+            data=data,
+            format="multipart",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(Movie.objects.filter(user=self.user).count(), 0)
+
+    def test_rating_update(self):
+        """Test that rating can be updated (changed)."""
+        movie_item = Item.objects.create(
+            media_id="603",
+            source="tmdb",
+            media_type=MediaTypes.MOVIE.value,
+            title="The Matrix",
+            image="https://example.com/matrix.jpg",
+        )
+        Movie.objects.create(
+            item=movie_item,
+            user=self.user,
+            progress=1,
+            status=Status.COMPLETED.value,
+            score=5.0,
+        )
+
+        payload = {
+            "event": "media.rate",
+            "Account": {"title": "testuser"},
+            "Metadata": {
+                "type": "movie",
+                "title": "The Matrix",
+                "userRating": 9,
+                "Guid": [{"id": "tmdb://603"}],
+            },
+        }
+
+        data = {"payload": json.dumps(payload)}
+
+        response = self.client.post(
+            self.url,
+            data=data,
+            format="multipart",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        movie = Movie.objects.get(item__media_id="603", user=self.user)
+        self.assertEqual(movie.score, 9.0)
+
+    def test_get_rating(self):
+        """Test extraction of rating from payload."""
+        payload_with_rating = {
+            "Metadata": {"userRating": 8}
+        }
+        payload_without_rating = {"Metadata": {"userRating": None}}
+        payload_no_field = {"Metadata": {}}
+
+        processor = PlexWebhookProcessor()
+
+        self.assertEqual(processor._get_rating(payload_with_rating), 8.0)
+        self.assertIsNone(processor._get_rating(payload_without_rating))
+        self.assertIsNone(processor._get_rating(payload_no_field))
+
+    def test_is_rating_event(self):
+        """Test detection of rating events."""
+        rating_payload = {"event": "media.rate"}
+        scrobble_payload = {"event": "media.scrobble"}
+        play_payload = {"event": "media.play"}
+
+        processor = PlexWebhookProcessor()
+
+        self.assertTrue(processor._is_rating_event(rating_payload))
+        self.assertFalse(processor._is_rating_event(scrobble_payload))
+        self.assertFalse(processor._is_rating_event(play_payload))
+
+    def test_anime_tv_rating(self):
+        """Test webhook handles anime TV show rating event via TVDB mapping."""
+        anime_item = Item.objects.create(
+            media_id="52991",
+            source="mal",
+            media_type=MediaTypes.ANIME.value,
+            title="Frieren: Beyond Journey's End",
+            image="https://example.com/frieren.jpg",
+        )
+        Anime.objects.create(
+            item=anime_item,
+            user=self.user,
+            progress=1,
+            status=Status.IN_PROGRESS.value,
+            score=None,
+        )
+
+        payload = {
+            "event": "media.rate",
+            "Account": {"title": "testuser"},
+            "Metadata": {
+                "type": "show",
+                "title": "Frieren: Beyond Journey's End",
+                "userRating": 9,
+                "parentIndex": 1,
+                "Guid": [
+                    {"id": "tmdb://39462"},
+                    {"id": "tvdb://9350138"},
+                ],
+            },
+        }
+
+        data = {"payload": json.dumps(payload)}
+
+        response = self.client.post(
+            self.url,
+            data=data,
+            format="multipart",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        anime = Anime.objects.get(item__media_id="52991", user=self.user)
+        self.assertEqual(anime.score, 9.0)
+
+    def test_movie_played_with_rating(self):
+        """Test webhook handles movie playback with rating."""
+        payload = {
+            "event": "media.scrobble",
+            "Account": {"title": "testuser"},
+            "Metadata": {
+                "type": "movie",
+                "title": "The Matrix",
+                "userRating": 8,
+                "Guid": [
+                    {"id": "imdb://tt0133093"},
+                    {"id": "tmdb://603"},
+                ],
+            },
+        }
+
+        data = {"payload": json.dumps(payload)}
+
+        response = self.client.post(
+            self.url,
+            data=data,
+            format="multipart",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        movie = Movie.objects.get(item__media_id="603", user=self.user)
+        self.assertEqual(movie.status, Status.COMPLETED.value)
+        self.assertEqual(movie.progress, 1)
+        self.assertEqual(movie.score, 8.0)
+
+    def test_episode_played_with_rating(self):
+        """Test webhook handles TV episode playback with rating."""
+        payload = {
+            "event": "media.scrobble",
+            "Account": {"title": "testuser"},
+            "Metadata": {
+                "type": "episode",
+                "grandparentTitle": "Friends",
+                "index": 1,
+                "parentIndex": 1,
+                "userRating": 7,
+                "Guid": [
+                    {"id": "imdb://tt0583459"},
+                    {"id": "tmdb://85987"},
+                    {"id": "tvdb://303821"},
+                ],
+            },
+        }
+
+        data = {"payload": json.dumps(payload)}
+
+        response = self.client.post(
+            self.url,
+            data=data,
+            format="multipart",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        tv_item = Item.objects.get(media_type=MediaTypes.TV.value, media_id="1668")
+        self.assertEqual(tv_item.title, "Friends")
+
+        tv = TV.objects.get(item=tv_item, user=self.user)
+        self.assertEqual(tv.status, Status.IN_PROGRESS.value)
+
+        season = Season.objects.get(
+            item__media_id="1668",
+            item__season_number=1,
+        )
+        self.assertEqual(season.status, Status.IN_PROGRESS.value)
+
+        episode = Episode.objects.get(
+            item__media_id="1668",
+            item__season_number=1,
+            item__episode_number=1,
+        )
+        self.assertIsNotNone(episode.end_date)
+
+    def test_anime_episode_played_with_rating(self):
+        """Test webhook handles anime episode playback with rating."""
+        payload = {
+            "event": "media.scrobble",
+            "Account": {"title": "testuser"},
+            "Metadata": {
+                "type": "episode",
+                "grandparentTitle": "Frieren: Beyond Journey's End",
+                "index": 1,
+                "parentIndex": 1,
+                "userRating": 9,
+                "Guid": [
+                    {"id": "imdb://tt23861604"},
+                    {"id": "tmdb://3946240"},
+                    {"id": "tvdb://9350138"},
+                ],
+            },
+        }
+
+        data = {"payload": json.dumps(payload)}
+
+        response = self.client.post(
+            self.url,
+            data=data,
+            format="multipart",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        anime = Anime.objects.get(item__media_id="52991", user=self.user)
+        self.assertEqual(anime.status, Status.IN_PROGRESS.value)
+        self.assertEqual(anime.progress, 1)
+        self.assertEqual(anime.score, 9.0)
+
+    def test_anime_movie_played_with_rating(self):
+        """Test webhook handles anime movie playback with rating."""
+        payload = {
+            "event": "media.scrobble",
+            "Account": {"title": "testuser"},
+            "Metadata": {
+                "type": "movie",
+                "title": "Perfect Blue",
+                "userRating": 10,
+                "Guid": [
+                    {"id": "imdb://tt0156887"},
+                    {"id": "tmdb://10494"},
+                ],
+            },
+        }
+
+        data = {"payload": json.dumps(payload)}
+
+        response = self.client.post(
+            self.url,
+            data=data,
+            format="multipart",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        anime = Anime.objects.get(item__media_id="437", user=self.user)
+        self.assertEqual(anime.status, Status.COMPLETED.value)
+        self.assertEqual(anime.progress, 1)
+        self.assertEqual(anime.score, 10.0)
+
+    def test_movie_rating_zero(self):
+        """Test webhook handles movie rating of 0."""
+        movie_item = Item.objects.create(
+            media_id="603",
+            source="tmdb",
+            media_type=MediaTypes.MOVIE.value,
+            title="The Matrix",
+            image="https://example.com/matrix.jpg",
+        )
+        Movie.objects.create(
+            item=movie_item,
+            user=self.user,
+            progress=1,
+            status=Status.COMPLETED.value,
+            score=None,
+        )
+
+        payload = {
+            "event": "media.rate",
+            "Account": {"title": "testuser"},
+            "Metadata": {
+                "type": "movie",
+                "title": "The Matrix",
+                "userRating": 0,
+                "Guid": [{"id": "tmdb://603"}],
+            },
+        }
+
+        data = {"payload": json.dumps(payload)}
+        response = self.client.post(self.url, data=data, format="multipart")
+
+        self.assertEqual(response.status_code, 200)
+        movie = Movie.objects.get(item__media_id="603", user=self.user)
+        self.assertEqual(movie.score, 0.0)
+
+    def test_rating_out_of_range(self):
+        """Test that out-of-range ratings are ignored."""
+        payload_high = {"Metadata": {"userRating": 15}}
+        payload_negative = {"Metadata": {"userRating": -1}}
+
+        processor = PlexWebhookProcessor()
+
+        self.assertIsNone(processor._get_rating_from_payload(payload_high))
+        self.assertIsNone(processor._get_rating_from_payload(payload_negative))
+
+    def test_rating_on_completed_movie(self):
+        """Test that rating a completed movie updates the score.
+
+        Regression test for issue where rating updates were not applied
+        to already-completed media items.
+        """
+        movie_item = Item.objects.create(
+            media_id="603",
+            source="tmdb",
+            media_type=MediaTypes.MOVIE.value,
+            title="The Matrix",
+            image="https://example.com/matrix.jpg",
+        )
+        Movie.objects.create(
+            item=movie_item,
+            user=self.user,
+            progress=1,
+            status=Status.COMPLETED.value,
+            score=None,
+        )
+
+        payload = {
+            "event": "media.rate",
+            "Account": {"title": "testuser"},
+            "Metadata": {
+                "type": "movie",
+                "title": "The Matrix",
+                "userRating": 8,
+                "Guid": [{"id": "tmdb://603"}],
+            },
+        }
+
+        data = {"payload": json.dumps(payload)}
+        response = self.client.post(self.url, data=data, format="multipart")
+
+        self.assertEqual(response.status_code, 200)
+        movie = Movie.objects.get(item__media_id="603", user=self.user)
+        self.assertEqual(movie.score, 8.0)
+
+    def test_rating_on_completed_anime(self):
+        """Test that rating a completed anime updates the score.
+
+        Regression test for issue where rating updates were not applied
+        to already-completed anime items.
+        """
+        anime_item = Item.objects.create(
+            media_id="437",
+            source="mal",
+            media_type=MediaTypes.ANIME.value,
+            title="Perfect Blue",
+            image="https://example.com/perfectblue.jpg",
+        )
+        Anime.objects.create(
+            item=anime_item,
+            user=self.user,
+            progress=1,
+            status=Status.COMPLETED.value,
+            score=None,
+        )
+
+        payload = {
+            "event": "media.rate",
+            "Account": {"title": "testuser"},
+            "Metadata": {
+                "type": "movie",
+                "title": "Perfect Blue",
+                "userRating": 9,
+                "Guid": [
+                    {"id": "tmdb://10494"},
+                    {"id": "imdb://tt0156887"},
+                ],
+            },
+        }
+
+        data = {"payload": json.dumps(payload)}
+        response = self.client.post(self.url, data=data, format="multipart")
+
+        self.assertEqual(response.status_code, 200)
+        anime = Anime.objects.get(item__media_id="437", user=self.user)
+        self.assertEqual(anime.score, 9.0)

--- a/src/integrations/webhooks/base.py
+++ b/src/integrations/webhooks/base.py
@@ -343,9 +343,7 @@ class BaseWebhookProcessor:
                 user=user,
                 progress=progress,
                 status=(
-                    Status.COMPLETED.value
-                    if movie_played
-                    else Status.IN_PROGRESS.value
+                    Status.COMPLETED.value if movie_played else Status.IN_PROGRESS.value
                 ),
                 start_date=now if not movie_played else None,
                 end_date=now if movie_played else None,
@@ -354,7 +352,7 @@ class BaseWebhookProcessor:
             logger.info(
                 "Created new movie instance with status: %s%s",
                 Status.COMPLETED.value if movie_played else Status.IN_PROGRESS.value,
-                f" and rating: {rating}" if rating else "",
+                f" and rating: {rating}" if rating is not None else "",
             )
 
     def _handle_tv_episode(
@@ -560,7 +558,7 @@ class BaseWebhookProcessor:
                 "Created new anime instance with status: %s and progress %d%s",
                 status,
                 episode_number,
-                f" and rating: {rating}" if rating else "",
+                f" and rating: {rating}" if rating is not None else "",
             )
 
     def _handle_rating(self, media_type, media_id, source, rating, user):

--- a/src/integrations/webhooks/base.py
+++ b/src/integrations/webhooks/base.py
@@ -4,7 +4,7 @@ from django.core.cache import cache
 from django.utils import timezone
 
 import app
-from app.models import MediaTypes, Sources, Status
+from app.models import Anime, Item, MediaTypes, Movie, Sources, Status, TV
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +15,8 @@ class BaseWebhookProcessor:
     MEDIA_TYPE_MAPPING = {
         "Episode": MediaTypes.TV.value,
         "Movie": MediaTypes.MOVIE.value,
+        "Show": MediaTypes.TV.value,
+        "Season": MediaTypes.TV.value,
     }
 
     def process_payload(self, payload, user):
@@ -56,7 +58,22 @@ class BaseWebhookProcessor:
         elif media_type == MediaTypes.MOVIE.value:
             self._process_movie(payload, user, ids)
 
+    def _get_rating_from_payload(self, payload):
+        """Extract rating from payload if present.
+
+        Plex uses payload["Metadata"].get("userRating").
+        Returns None if no rating is present or if rating is out of range.
+        """
+        rating = payload.get("Metadata", {}).get("userRating")
+        if rating is not None:
+            rating = float(rating)
+            if 0 <= rating <= 10:
+                return rating
+            logger.warning("Rating %s out of range (0-10), ignoring", rating)
+        return None
+
     def _process_tv(self, payload, user, ids):
+        rating = self._get_rating_from_payload(payload)
         anidb_id = ids.get("anidb_id")
         if user.anime_enabled and anidb_id:
             mapping_data = self._fetch_mapping_data()
@@ -85,6 +102,7 @@ class BaseWebhookProcessor:
                     episode_number,
                     payload,
                     user,
+                    rating,
                 )
                 return
 
@@ -115,7 +133,7 @@ class BaseWebhookProcessor:
                     mal_id,
                     episode_offset,
                 )
-                self._handle_anime(mal_id, episode_offset, payload, user)
+                self._handle_anime(mal_id, episode_offset, payload, user, rating)
                 return
 
         logger.info(
@@ -124,11 +142,14 @@ class BaseWebhookProcessor:
             season_number,
             episode_number,
         )
-        self._handle_tv_episode(media_id, season_number, episode_number, payload, user)
+        self._handle_tv_episode(
+            media_id, season_number, episode_number, payload, user, rating
+        )
 
     def _process_movie(self, payload, user, ids):
         tmdb_id = ids["tmdb_id"]
         imdb_id = ids["imdb_id"]
+        rating = self._get_rating_from_payload(payload)
 
         # Try to detect anime first if user has anime enabled
         if user.anime_enabled:
@@ -150,13 +171,13 @@ class BaseWebhookProcessor:
                     mal_id,
                     source,
                 )
-                self._handle_anime(mal_id, 1, payload, user)
+                self._handle_anime(mal_id, 1, payload, user, rating)
                 return
 
         # Handle as regular movie
         if tmdb_id:
             logger.info("Detected movie via TMDB ID: %s", tmdb_id)
-            self._handle_movie(tmdb_id, payload, user)
+            self._handle_movie(tmdb_id, payload, user, rating)
         elif imdb_id:
             logger.debug("No TMDB ID found, looking up via IMDB ID: %s", imdb_id)
             response = app.providers.tmdb.find(imdb_id, "imdb_id")
@@ -164,7 +185,7 @@ class BaseWebhookProcessor:
             if response.get("movie_results"):
                 media_id = response["movie_results"][0]["id"]
                 logger.info("Found matching TMDB ID: %s", media_id)
-                self._handle_movie(media_id, payload, user)
+                self._handle_movie(media_id, payload, user, rating)
             else:
                 logger.warning(
                     "No matching TMDB ID found for IMDB ID: %s",
@@ -255,8 +276,15 @@ class BaseWebhookProcessor:
             return mal_id.split(",")[0].strip()
         return mal_id
 
-    def _handle_movie(self, media_id, payload, user):
-        """Handle movie playback event."""
+    def _handle_movie(self, media_id, payload, user, rating=None):
+        """Handle movie playback event.
+
+        Args:
+            media_id: The TMDB ID of the movie
+            payload: The webhook payload
+            user: The user instance
+            rating: Optional rating value (1-10) from the payload
+        """
         movie_metadata = app.providers.tmdb.movie(media_id)
         movie_item, _ = app.models.Item.objects.get_or_create(
             media_id=media_id,
@@ -275,16 +303,28 @@ class BaseWebhookProcessor:
         progress = 1 if movie_played else 0
         now = timezone.now().replace(second=0, microsecond=0)
 
-        if current_instance and current_instance.status != Status.COMPLETED.value:
-            current_instance.progress = progress
+        if current_instance:
+            if current_instance.status != Status.COMPLETED.value:
+                current_instance.progress = progress
 
-            if movie_played:
-                current_instance.end_date = now
-                current_instance.status = Status.COMPLETED.value
+                if movie_played:
+                    current_instance.end_date = now
+                    current_instance.status = Status.COMPLETED.value
 
-            elif current_instance.status != Status.IN_PROGRESS.value:
-                current_instance.start_date = now
-                current_instance.status = Status.IN_PROGRESS.value
+                elif current_instance.status != Status.IN_PROGRESS.value:
+                    current_instance.start_date = now
+                    current_instance.status = Status.IN_PROGRESS.value
+
+            if rating is not None:
+                old_score = current_instance.score
+                current_instance.score = rating
+                if old_score != rating:
+                    logger.info(
+                        "Updated rating for movie %s from %s to %s",
+                        movie_metadata["title"],
+                        old_score,
+                        rating,
+                    )
 
             if current_instance.tracker.changed():
                 current_instance.save()
@@ -302,15 +342,19 @@ class BaseWebhookProcessor:
                 item=movie_item,
                 user=user,
                 progress=progress,
-                status=Status.COMPLETED.value
-                if movie_played
-                else Status.IN_PROGRESS.value,
+                status=(
+                    Status.COMPLETED.value
+                    if movie_played
+                    else Status.IN_PROGRESS.value
+                ),
                 start_date=now if not movie_played else None,
                 end_date=now if movie_played else None,
+                score=rating,
             )
             logger.info(
-                "Created new movie instance with status: %s",
+                "Created new movie instance with status: %s%s",
                 Status.COMPLETED.value if movie_played else Status.IN_PROGRESS.value,
+                f" and rating: {rating}" if rating else "",
             )
 
     def _handle_tv_episode(
@@ -436,8 +480,16 @@ class BaseWebhookProcessor:
                 episode_number,
             )
 
-    def _handle_anime(self, media_id, episode_number, payload, user):
-        """Handle anime playback event."""
+    def _handle_anime(self, media_id, episode_number, payload, user, rating=None):
+        """Handle anime playback event.
+
+        Args:
+            media_id: The MAL ID of the anime
+            episode_number: The episode number
+            payload: The webhook payload
+            user: The user instance
+            rating: Optional rating value (1-10) from the payload
+        """
         anime_metadata = app.providers.mal.anime(media_id)
         anime_item, _ = app.models.Item.objects.get_or_create(
             media_id=media_id,
@@ -459,16 +511,28 @@ class BaseWebhookProcessor:
         is_completed = episode_number == anime_metadata["max_progress"]
         status = Status.COMPLETED.value if is_completed else Status.IN_PROGRESS.value
 
-        if current_instance and current_instance.status != Status.COMPLETED.value:
-            current_instance.progress = episode_number
+        if current_instance:
+            if current_instance.status != Status.COMPLETED.value:
+                current_instance.progress = episode_number
 
-            if is_completed:
-                current_instance.end_date = now
-                current_instance.status = status
+                if is_completed:
+                    current_instance.end_date = now
+                    current_instance.status = status
 
-            elif current_instance.status != Status.IN_PROGRESS.value:
-                current_instance.start_date = now
-                current_instance.status = status
+                elif current_instance.status != Status.IN_PROGRESS.value:
+                    current_instance.start_date = now
+                    current_instance.status = status
+
+            if rating is not None:
+                old_score = current_instance.score
+                current_instance.score = rating
+                if old_score != rating:
+                    logger.info(
+                        "Updated rating for anime %s from %s to %s",
+                        anime_metadata["title"],
+                        old_score,
+                        rating,
+                    )
 
             if current_instance.tracker.changed():
                 current_instance.save()
@@ -490,9 +554,81 @@ class BaseWebhookProcessor:
                 status=status,
                 start_date=now if not is_completed else None,
                 end_date=now if is_completed else None,
+                score=rating,
             )
             logger.info(
-                "Created new anime instance with status: %s and progress %d",
+                "Created new anime instance with status: %s and progress %d%s",
                 status,
                 episode_number,
+                f" and rating: {rating}" if rating else "",
+            )
+
+    def _handle_rating(self, media_type, media_id, source, rating, user):
+        """Handle rating update event for a media item.
+
+        Args:
+            media_type: The type of media (movie, tv, anime)
+            media_id: The external ID of the media
+            source: The source of the ID (tmdb, mal, etc.)
+            rating: The rating value (1-10) or None
+            user: The user instance
+        """
+        item, item_created = Item.objects.get_or_create(
+            media_id=media_id,
+            source=source,
+            media_type=media_type,
+            defaults={
+                "title": f"Media {media_id}",
+                "image": "",
+            },
+        )
+
+        if item_created:
+            metadata = app.providers.services.get_media_metadata(
+                media_type, media_id, source
+            )
+            if metadata:
+                item.title = metadata.get("title") or item.title
+                item.image = metadata.get("image") or item.image
+                item.save()
+            else:
+                logger.debug(
+                    "Failed to fetch metadata for %s %s, using placeholder",
+                    media_type,
+                    media_id,
+                )
+
+        if media_type == MediaTypes.MOVIE.value:
+            instances = Movie.objects.filter(item=item, user=user)
+        elif media_type == MediaTypes.TV.value:
+            instances = TV.objects.filter(item=item, user=user)
+        elif media_type == MediaTypes.ANIME.value:
+            instances = Anime.objects.filter(item=item, user=user)
+        else:
+            logger.warning("Unsupported media type for rating: %s", media_type)
+            return
+
+        if instances.exists():
+            instance = instances.first()
+            old_score = instance.score
+            instance.score = rating
+            if instance.tracker.changed():
+                instance.save()
+                logger.info(
+                    "Updated rating for %s: %s from %s to %s",
+                    media_type,
+                    item.title,
+                    old_score,
+                    rating,
+                )
+            else:
+                logger.info(
+                    "Rating unchanged for %s: %s",
+                    media_type,
+                    item.title,
+                )
+        else:
+            logger.debug(
+                "Media %s not in user's list, skipping rating update",
+                item.title,
             )

--- a/src/integrations/webhooks/base.py
+++ b/src/integrations/webhooks/base.py
@@ -72,69 +72,153 @@ class BaseWebhookProcessor:
             logger.warning("Rating %s out of range (0-10), ignoring", rating)
         return None
 
+    def _try_detect_anime(
+        self,
+        ids,
+        user,
+        payload,
+        media_type=None,
+        season_number=None,
+    ):
+        """Try to detect if media is anime and return MAL ID.
+
+        Args:
+            ids: Dictionary of external IDs (tmdb_id, imdb_id, tvdb_id, anidb_id)
+            user: The user instance
+            payload: The webhook payload
+            media_type: Optional media type (for TV-specific detection)
+            season_number: Optional season number (for TV-specific detection)
+
+        Returns:
+            Tuple of (is_anime, mal_id, source, episode_number)
+            is_anime: True if anime was detected
+            mal_id: MAL ID if detected, None otherwise
+            source: Source of the ID ("anidb", "tvdb", "tmdb", "imdb")
+            episode_number: Episode number if applicable, None otherwise
+        """
+        if not user.anime_enabled:
+            return False, None, None, None
+
+        mapping_data = self._fetch_mapping_data()
+
+        if (res := self._detect_anime_from_anidb(ids, payload, mapping_data))[0]:
+            return res
+
+        if (res := self._detect_anime_from_tvdb(
+                ids, payload, mapping_data, media_type, season_number
+            )
+        )[0]:
+            return res
+
+        if (res := self._detect_anime_from_tmdb(ids, mapping_data))[0]:
+            return res
+
+        if (res := self._detect_anime_from_imdb(ids, mapping_data))[0]:
+            return res
+
+        return False, None, None, None
+
+    def _detect_anime_from_anidb(self, ids, payload, mapping_data):
+        """Detect anime from AniDB ID."""
+        anidb_id = ids.get("anidb_id")
+        if not anidb_id:
+            return False, None, None, None
+
+        matching_entry = mapping_data.get(anidb_id)
+        if not matching_entry or "mal_id" not in matching_entry:
+            logger.debug(
+                "AniDB ID %s not found in mapping or has no MAL ID",
+                anidb_id,
+            )
+            return False, None, None, None
+
+        episode_number = payload["Metadata"].get("index")
+        if not episode_number:
+            logger.warning(
+                "No episode number found for AniDB ID: %s",
+                anidb_id,
+            )
+            return False, None, None, None
+
+        mal_id = self._parse_mal_id(matching_entry["mal_id"])
+        logger.info(
+            "Detected anime via AniDB ID: %s, MAL ID: %s, Episode: %d",
+            anidb_id,
+            mal_id,
+            episode_number,
+        )
+        return True, mal_id, "anidb", episode_number
+
+    def _detect_anime_from_tvdb(
+        self, ids, payload, mapping_data, media_type, season_number
+    ):
+        """Detect anime from TVDB ID."""
+        tvdb_id = ids.get("tvdb_id")
+        if not tvdb_id or media_type != MediaTypes.TV.value:
+            return False, None, None, None
+
+        actual_season = season_number or payload["Metadata"].get("parentIndex") or 1
+        episode_number = payload["Metadata"].get("index") or 1
+        mal_id, episode_offset = self._get_mal_id_from_tvdb(
+            mapping_data, int(tvdb_id), actual_season, episode_number
+        )
+        if mal_id:
+            logger.info(
+                "Detected anime TV via TVDB ID: %s S%d, MAL ID: %s",
+                tvdb_id,
+                actual_season,
+                mal_id,
+            )
+            return True, mal_id, "tvdb", episode_offset
+        return False, None, None, None
+
+    def _detect_anime_from_tmdb(self, ids, mapping_data):
+        """Detect anime from TMDB ID."""
+        tmdb_id = ids.get("tmdb_id")
+        if not tmdb_id:
+            return False, None, None, None
+
+        mal_id = self._get_mal_id_from_tmdb_movie(mapping_data, tmdb_id)
+        if mal_id:
+            logger.info(
+                "Detected anime via TMDB ID: %s, MAL ID: %s",
+                tmdb_id,
+                mal_id,
+            )
+            return True, mal_id, "tmdb", None
+        return False, None, None, None
+
+    def _detect_anime_from_imdb(self, ids, mapping_data):
+        """Detect anime from IMDB ID."""
+        imdb_id = ids.get("imdb_id")
+        if not imdb_id:
+            return False, None, None, None
+
+        mal_id = self._get_mal_id_from_imdb(mapping_data, imdb_id)
+        if mal_id:
+            logger.info(
+                "Detected anime via IMDB ID: %s, MAL ID: %s",
+                imdb_id,
+                mal_id,
+            )
+            return True, mal_id, "imdb", None
+        return False, None, None, None
+
     def _process_tv(self, payload, user, ids):
         rating = self._get_rating_from_payload(payload)
-        anidb_id = ids.get("anidb_id")
-        if user.anime_enabled and anidb_id:
-            mapping_data = self._fetch_mapping_data()
-            matching_entry = mapping_data.get(anidb_id)
-            if not matching_entry:
-                logger.info(
-                    "AniDB ID %s not found in mapping, "
-                    "falling through to TV processing",
-                    anidb_id,
-                )
-            elif not payload["Metadata"]["index"]:
-                logger.warning(
-                    "No episode number found for AniDB ID: %s",
-                    anidb_id,
-                )
-            else:
-                episode_number = payload["Metadata"]["index"]
-                logger.info(
-                    "Detected anime via AniDB ID: %s. Matching MAL ID: %s, Episode: %d",
-                    anidb_id,
-                    matching_entry["mal_id"],
-                    episode_number,
-                )
-                self._handle_anime(
-                    matching_entry["mal_id"],
-                    episode_number,
-                    payload,
-                    user,
-                    rating,
-                )
-                return
+
+        # Try anime detection first
+        is_anime, mal_id, source, anime_episode = self._try_detect_anime(
+            ids, user, payload, MediaTypes.TV.value
+        )
+        if is_anime:
+            self._handle_anime(mal_id, anime_episode, payload, user, rating)
+            return
 
         media_id, season_number, episode_number = self._find_tv_media_id(ids)
         if not media_id:
             logger.warning("No matching TMDB ID found for TV show")
             return
-
-        tvdb_id = app.providers.tmdb.tv_with_seasons(media_id, [season_number])[
-            "tvdb_id"
-        ]
-
-        if not tvdb_id:
-            logger.warning("No TVDB ID found for TMDB ID: %s", media_id)
-            return
-
-        if user.anime_enabled:
-            mapping_data = self._fetch_mapping_data()
-            mal_id, episode_offset = self._get_mal_id_from_tvdb(
-                mapping_data,
-                int(tvdb_id),
-                season_number,
-                episode_number,
-            )
-            if mal_id:
-                logger.info(
-                    "Detected anime episode via MAL ID: %s, Episode: %d",
-                    mal_id,
-                    episode_offset,
-                )
-                self._handle_anime(mal_id, episode_offset, payload, user, rating)
-                return
 
         logger.info(
             "Detected TV episode via TMDB ID: %s, Season: %d, Episode: %d",
@@ -142,37 +226,18 @@ class BaseWebhookProcessor:
             season_number,
             episode_number,
         )
-        self._handle_tv_episode(
-            media_id, season_number, episode_number, payload, user, rating
-        )
+        self._handle_tv_episode(media_id, season_number, episode_number, payload, user)
 
     def _process_movie(self, payload, user, ids):
         tmdb_id = ids["tmdb_id"]
         imdb_id = ids["imdb_id"]
         rating = self._get_rating_from_payload(payload)
 
-        # Try to detect anime first if user has anime enabled
-        if user.anime_enabled:
-            mapping_data = self._fetch_mapping_data()
-            mal_id = None
-            source = None
-
-            if tmdb_id:
-                mal_id = self._get_mal_id_from_tmdb_movie(mapping_data, tmdb_id)
-                source = "TMDB"
-
-            if not mal_id and imdb_id:
-                mal_id = self._get_mal_id_from_imdb(mapping_data, imdb_id)
-                source = "IMDB"
-
-            if mal_id:
-                logger.info(
-                    "Detected anime movie with MAL ID: %s (via %s)",
-                    mal_id,
-                    source,
-                )
-                self._handle_anime(mal_id, 1, payload, user, rating)
-                return
+        # Try anime detection first
+        is_anime, mal_id, _, _ = self._try_detect_anime(ids, user, payload)
+        if is_anime:
+            self._handle_anime(mal_id, 1, payload, user, rating)
+            return
 
         # Handle as regular movie
         if tmdb_id:

--- a/src/integrations/webhooks/plex.py
+++ b/src/integrations/webhooks/plex.py
@@ -74,90 +74,14 @@ class PlexWebhookProcessor(BaseWebhookProcessor):
         rating = self._get_rating_from_payload(payload)
         logger.info("Processing rating event: %s with rating %s", media_type, rating)
 
-        if user.anime_enabled:
-            mapping_data = self._fetch_mapping_data()
-
-            if ids.get("anidb_id"):
-                matching_entry = mapping_data.get(ids["anidb_id"])
-                if matching_entry and "mal_id" in matching_entry:
-                    mal_id = self._parse_mal_id(matching_entry["mal_id"])
-                    logger.info(
-                        "Detected anime via AniDB ID: %s, MAL ID: %s",
-                        ids["anidb_id"],
-                        mal_id,
-                    )
-                    self._handle_rating(
-                        MediaTypes.ANIME.value, mal_id, "mal", rating, user
-                    )
-                    return
-                else:
-                    logger.debug(
-                        "AniDB ID %s not found in mapping or has no MAL ID",
-                        ids["anidb_id"],
-                    )
-
-            tvdb_id = ids.get("tvdb_id")
-            if tvdb_id and media_type == MediaTypes.TV.value:
-                season_number = payload["Metadata"].get("parentIndex") or 1
-                mal_id, _ = self._get_mal_id_from_tvdb(
-                    mapping_data, int(tvdb_id), season_number, 1
-                )
-                if mal_id:
-                    logger.info(
-                        "Detected anime TV via TVDB ID: %s S%d, MAL ID: %s",
-                        tvdb_id,
-                        season_number,
-                        mal_id,
-                    )
-                    self._handle_rating(
-                        MediaTypes.ANIME.value, mal_id, "mal", rating, user
-                    )
-                    return
-                else:
-                    logger.debug(
-                        "TVDB ID %s S%d not found in anime mapping",
-                        tvdb_id,
-                        season_number,
-                    )
-
-            tmdb_id = ids.get("tmdb_id")
-            imdb_id = ids.get("imdb_id")
-
-            if tmdb_id:
-                mal_id = self._get_mal_id_from_tmdb_movie(mapping_data, tmdb_id)
-                if mal_id:
-                    logger.info(
-                        "Detected anime movie via TMDB ID: %s, MAL ID: %s",
-                        tmdb_id,
-                        mal_id,
-                    )
-                    self._handle_rating(
-                        MediaTypes.ANIME.value, mal_id, "mal", rating, user
-                    )
-                    return
-                else:
-                    logger.debug(
-                        "TMDB ID %s not found in anime mapping",
-                        tmdb_id,
-                    )
-
-            if imdb_id:
-                mal_id = self._get_mal_id_from_imdb(mapping_data, imdb_id)
-                if mal_id:
-                    logger.info(
-                        "Detected anime movie via IMDB ID: %s, MAL ID: %s",
-                        imdb_id,
-                        mal_id,
-                    )
-                    self._handle_rating(
-                        MediaTypes.ANIME.value, mal_id, "mal", rating, user
-                    )
-                    return
-                else:
-                    logger.debug(
-                        "IMDB ID %s not found in anime mapping",
-                        imdb_id,
-                    )
+        # Try anime detection first
+        season_number = payload["Metadata"].get("parentIndex")
+        is_anime, mal_id, source, _ = self._try_detect_anime(
+            ids, user, payload, media_type, season_number
+        )
+        if is_anime:
+            self._handle_rating(MediaTypes.ANIME.value, mal_id, "mal", rating, user)
+            return
 
         media_id = None
         source = "tmdb"

--- a/src/integrations/webhooks/plex.py
+++ b/src/integrations/webhooks/plex.py
@@ -36,10 +36,13 @@ class PlexWebhookProcessor(BaseWebhookProcessor):
             logger.warning("Ignoring Plex webhook call because no ID was found.")
             return
 
-        self._process_media(payload, user, ids)
+        if self._is_rating_event(payload):
+            self._process_rating(payload, user, ids)
+        else:
+            self._process_media(payload, user, ids)
 
     def _is_supported_event(self, event_type):
-        return event_type in ("media.scrobble", "media.play")
+        return event_type in ("media.scrobble", "media.play", "media.rate")
 
     def _is_valid_user(self, payload_user, user):
         stored_usernames = [
@@ -56,6 +59,120 @@ class PlexWebhookProcessor(BaseWebhookProcessor):
 
     def _is_played(self, payload):
         return payload["event"] == "media.scrobble"
+
+    def _is_rating_event(self, payload):
+        """Check if this is a rating event."""
+        return payload.get("event") == "media.rate"
+
+    def _process_rating(self, payload, user, ids):
+        """Process rating event."""
+        media_type = self._get_media_type(payload)
+        if not media_type:
+            logger.debug("Ignoring unsupported media type for rating")
+            return
+
+        rating = self._get_rating_from_payload(payload)
+        logger.info("Processing rating event: %s with rating %s", media_type, rating)
+
+        if user.anime_enabled:
+            mapping_data = self._fetch_mapping_data()
+
+            if ids.get("anidb_id"):
+                matching_entry = mapping_data.get(ids["anidb_id"])
+                if matching_entry and "mal_id" in matching_entry:
+                    mal_id = self._parse_mal_id(matching_entry["mal_id"])
+                    logger.info(
+                        "Detected anime via AniDB ID: %s, MAL ID: %s",
+                        ids["anidb_id"],
+                        mal_id,
+                    )
+                    self._handle_rating(
+                        MediaTypes.ANIME.value, mal_id, "mal", rating, user
+                    )
+                    return
+                else:
+                    logger.debug(
+                        "AniDB ID %s not found in mapping or has no MAL ID",
+                        ids["anidb_id"],
+                    )
+
+            tvdb_id = ids.get("tvdb_id")
+            if tvdb_id and media_type == MediaTypes.TV.value:
+                season_number = payload["Metadata"].get("parentIndex") or 1
+                mal_id, _ = self._get_mal_id_from_tvdb(
+                    mapping_data, int(tvdb_id), season_number, 1
+                )
+                if mal_id:
+                    logger.info(
+                        "Detected anime TV via TVDB ID: %s S%d, MAL ID: %s",
+                        tvdb_id,
+                        season_number,
+                        mal_id,
+                    )
+                    self._handle_rating(
+                        MediaTypes.ANIME.value, mal_id, "mal", rating, user
+                    )
+                    return
+                else:
+                    logger.debug(
+                        "TVDB ID %s S%d not found in anime mapping",
+                        tvdb_id,
+                        season_number,
+                    )
+
+            tmdb_id = ids.get("tmdb_id")
+            imdb_id = ids.get("imdb_id")
+
+            if tmdb_id:
+                mal_id = self._get_mal_id_from_tmdb_movie(mapping_data, tmdb_id)
+                if mal_id:
+                    logger.info(
+                        "Detected anime movie via TMDB ID: %s, MAL ID: %s",
+                        tmdb_id,
+                        mal_id,
+                    )
+                    self._handle_rating(
+                        MediaTypes.ANIME.value, mal_id, "mal", rating, user
+                    )
+                    return
+                else:
+                    logger.debug(
+                        "TMDB ID %s not found in anime mapping",
+                        tmdb_id,
+                    )
+
+            if imdb_id:
+                mal_id = self._get_mal_id_from_imdb(mapping_data, imdb_id)
+                if mal_id:
+                    logger.info(
+                        "Detected anime movie via IMDB ID: %s, MAL ID: %s",
+                        imdb_id,
+                        mal_id,
+                    )
+                    self._handle_rating(
+                        MediaTypes.ANIME.value, mal_id, "mal", rating, user
+                    )
+                    return
+                else:
+                    logger.debug(
+                        "IMDB ID %s not found in anime mapping",
+                        imdb_id,
+                    )
+
+        media_id = None
+        source = None
+
+        if ids.get("tmdb_id"):
+            media_id = ids["tmdb_id"]
+            source = "tmdb"
+        elif ids.get("imdb_id"):
+            media_id = ids["imdb_id"]
+            source = "imdb"
+        else:
+            logger.warning("No valid ID found for rating event")
+            return
+
+        self._handle_rating(media_type, media_id, source, rating, user)
 
     def _get_media_type(self, payload):
         media_type = payload["Metadata"].get("type")

--- a/src/integrations/webhooks/plex.py
+++ b/src/integrations/webhooks/plex.py
@@ -160,19 +160,40 @@ class PlexWebhookProcessor(BaseWebhookProcessor):
                     )
 
         media_id = None
-        source = None
+        source = "tmdb"
 
         if ids.get("tmdb_id"):
             media_id = ids["tmdb_id"]
-            source = "tmdb"
-        elif ids.get("imdb_id"):
-            media_id = ids["imdb_id"]
-            source = "imdb"
+        elif media_type == MediaTypes.TV.value and ids.get("tvdb_id"):
+            logger.debug("No TMDB ID found, looking up via TVDB ID: %s", ids["tvdb_id"])
+            response = app.providers.tmdb.find(ids["tvdb_id"], "tvdb_id")
+
+            if response.get("tv_results"):
+                media_id = response["tv_results"][0]["id"]
+                logger.info("Found matching TMDB ID: %s", media_id)
+            else:
+                logger.warning(
+                    "No matching TMDB ID found for TVDB ID: %s",
+                    ids["tvdb_id"],
+                )
+        elif media_type == MediaTypes.MOVIE.value and ids.get("imdb_id"):
+            logger.debug("No TMDB ID found, looking up via IMDB ID: %s", ids["imdb_id"])
+            response = app.providers.tmdb.find(ids["imdb_id"], "imdb_id")
+
+            if response.get("movie_results"):
+                media_id = response["movie_results"][0]["id"]
+                logger.info("Found matching TMDB ID: %s", media_id)
+            else:
+                logger.warning(
+                    "No matching TMDB ID found for IMDB ID: %s",
+                    ids["imdb_id"],
+                )
         else:
             logger.warning("No valid ID found for rating event")
             return
 
-        self._handle_rating(media_type, media_id, source, rating, user)
+        if media_id:
+            self._handle_rating(media_type, media_id, source, rating, user)
 
     def _get_media_type(self, payload):
         media_type = payload["Metadata"].get("type")


### PR DESCRIPTION
Implements support for the Plex media.rate webhook event, allowing users to automatically sync their Plex ratings to Yamtrack.

Changes:
- Added _handle_rating() method to BaseWebhookProcessor for rating updates
- Modified _handle_movie(), _handle_anime() to accept optional rating parameter for playback events
- Added _get_rating_from_payload() helper to extract ratings from payloads
- Added _process_rating() in PlexWebhookProcessor, including anime detection (AniDB, TVDB, TMDB movie, IMDB)
- Expanded MEDIA_TYPE_MAPPING to support Show and Season types for ratings
- Added tests for rating events and playback with ratings

Resolves: #1223

From my limited testing on my own library it seems to work well, but
more testing would be appreciated, in case I missed some edge scenarios.