### PR TITLE
fix: use absolute URL for Trakt OAuth token refresh redirect_uri

### DIFF
--- a/src/integrations/imports/trakt.py
+++ b/src/integrations/imports/trakt.py
@@ -91,7 +91,7 @@ def get_access_token(encrypted_refresh_token):
         "client_secret": settings.TRAKT_API_SECRET,
         "refresh_token": decrypted_token,
         "grant_type": "refresh_token",
-        "redirect_uri": f"{settings.URLS[0]}{reverse('import_trakt_private')}",
+        "redirect_uri": f"{settings.URLS[0].rstrip('/')}{reverse('import_trakt_private')}",
     }
 
     try:

--- a/src/integrations/imports/trakt.py
+++ b/src/integrations/imports/trakt.py
@@ -91,7 +91,7 @@ def get_access_token(encrypted_refresh_token):
         "client_secret": settings.TRAKT_API_SECRET,
         "refresh_token": decrypted_token,
         "grant_type": "refresh_token",
-        "redirect_uri": f"{settings.BASE_URL}/import/trakt/private",
+        "redirect_uri": f"{settings.URLS[0]}{reverse('import_trakt_private')}",
     }
 
     try:


### PR DESCRIPTION
## Summary
- Fix `get_access_token()` to build the `redirect_uri` using `settings.URLS[0] + reverse()` instead of `settings.BASE_URL` alone
- This ensures the redirect_uri matches the one sent during initial OAuth authorization via `request.build_absolute_uri()`
- Without this fix, deployments on a subpath (`BASE_URL=/yamtrack`) get a 400 from Trakt's token endpoint

Fixes #1023

## Test plan
- Deploy Yamtrack on a subpath (e.g. `/yamtrack`) behind a reverse proxy
- Configure Trakt OAuth and perform an initial import
- Wait for the access token to expire and trigger a refresh (or manually invalidate it)
- Verify the refresh succeeds instead of returning 400