### PR TITLE
Store season progress as a DB field

### DIFF
--- a/src/app/forms.py
+++ b/src/app/forms.py
@@ -352,9 +352,13 @@ class SeasonForm(MediaForm):
         model = Season
         fields = [
             "score",
+            "progress",
             "status",
             "notes",
         ]
+        labels = {
+            "progress": "Episode Progress",
+        }
 
 
 class EpisodeForm(forms.ModelForm):

--- a/src/app/migrations/0061_season_progress_stored.py
+++ b/src/app/migrations/0061_season_progress_stored.py
@@ -1,0 +1,67 @@
+from django.db import migrations, models
+
+
+def populate_season_progress(apps, schema_editor):
+    """Set Season.progress using the original computed logic:
+    - IN_PROGRESS: episode with highest rewatch count (ties broken by highest episode number)
+    - Other statuses: highest watched episode number
+    """
+    Season = apps.get_model("app", "Season")
+    Episode = apps.get_model("app", "Episode")
+
+    in_progress_status = "In progress"
+
+    # Gather all episodes grouped by season
+    episodes_by_season = {}
+    for ep in Episode.objects.values("related_season_id", "item__episode_number"):
+        sid = ep["related_season_id"]
+        if sid not in episodes_by_season:
+            episodes_by_season[sid] = []
+        episodes_by_season[sid].append(ep["item__episode_number"] or 0)
+
+    seasons_to_update = []
+    for season in Season.objects.filter(pk__in=episodes_by_season.keys()):
+        ep_numbers = episodes_by_season[season.pk]
+
+        if season.status == in_progress_status:
+            # Count rewatches per episode number, pick highest count then highest number
+            episode_counts = {}
+            for ep_num in ep_numbers:
+                episode_counts[ep_num] = episode_counts.get(ep_num, 0) + 1
+            new_progress = max(
+                episode_counts,
+                key=lambda n: (episode_counts[n], n),
+            )
+        else:
+            new_progress = max(ep_numbers)
+
+        if season.progress != new_progress:
+            season.progress = new_progress
+            seasons_to_update.append(season)
+
+    if seasons_to_update:
+        Season.objects.bulk_update(seasons_to_update, ["progress"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("app", "0060_fix_reopened_completed_tv_seasons"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="season",
+            name="progress",
+            field=models.PositiveIntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name="historicalseason",
+            name="progress",
+            field=models.PositiveIntegerField(default=0),
+        ),
+        migrations.RunPython(
+            populate_season_progress,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -363,12 +363,8 @@ class MediaManager(models.Manager):
             )
 
         if sort_filter == "progress":
-            # Annotate with the maximum episode number
-            queryset = queryset.annotate(
-                calculated_progress=models.Max("episodes__item__episode_number"),
-            )
             return queryset.order_by(
-                "-calculated_progress",
+                "-progress",
                 models.functions.Lower("item__title"),
             )
 
@@ -1159,6 +1155,20 @@ class TV(Media):
                 "as watched automatically.",
                 level=UserMessageLevel.INFO,
             )
+            # Update season progress for each season that got new episodes
+            season_ep_max = {}
+            for ep in episodes_to_create:
+                sid = ep.related_season_id
+                ep_num = ep.item.episode_number
+                season_ep_max[sid] = max(season_ep_max.get(sid, 0), ep_num)
+            seasons_to_update_progress = []
+            for season in seasons_to_create + seasons_to_update:
+                new_progress = max(season.progress, season_ep_max.get(season.pk, 0))
+                if new_progress != season.progress:
+                    season.progress = new_progress
+                    seasons_to_update_progress.append(season)
+            if seasons_to_update_progress:
+                Season.objects.bulk_update(seasons_to_update_progress, ["progress"])
 
         if not tv_completed:
             self.status = Status.IN_PROGRESS.value
@@ -1397,6 +1407,13 @@ class Season(Media):
                         "marked as watched automatically.",
                         level=UserMessageLevel.INFO,
                     )
+                    max_ep_num = max(
+                        ep.item.episode_number for ep in episodes_to_create
+                    )
+                    new_progress = max(self.progress, max_ep_num)
+                    if self.progress != new_progress:
+                        self.progress = new_progress
+                        Season.objects.bulk_update([self], ["progress"])
 
                 if target_status == Status.COMPLETED.value:
                     self.related_tv._handle_completed_season(
@@ -1484,37 +1501,6 @@ class Season(Media):
             return Status.IN_PROGRESS.value
 
         return unreleased_only_status
-
-    @property
-    def progress(self):
-        """Return the current episode number of the season."""
-        episodes = self.episodes.all()
-        if not episodes:
-            return 0
-
-        if self.status == Status.IN_PROGRESS.value:
-            # Calculate repeat counts for each episode number
-            episode_counts = {}
-            for ep in episodes:
-                ep_num = ep.item.episode_number
-                episode_counts[ep_num] = episode_counts.get(ep_num, 0) + 1
-
-            # Sort by repeat count then episode_number
-            sorted_episodes = sorted(
-                episodes,
-                key=lambda e: (
-                    -episode_counts[e.item.episode_number],
-                    -e.item.episode_number,
-                ),
-            )
-        else:
-            # Default sorting by episode_number
-            sorted_episodes = sorted(
-                episodes,
-                key=lambda e: -e.item.episode_number,
-            )
-
-        return sorted_episodes[0].item.episode_number
 
     @property
     def progressed_at(self):
@@ -1619,6 +1605,18 @@ class Season(Media):
             episode_number,
             remaining_count,
         )
+
+        # Recalculate progress from remaining watched episodes
+        remaining = (
+            Episode.objects.filter(related_season=self)
+            .order_by("-item__episode_number")
+            .select_related("item")
+            .first()
+        )
+        new_progress = remaining.item.episode_number if remaining else 0
+        if self.progress != new_progress:
+            self.progress = new_progress
+            Season.objects.filter(pk=self.pk).update(progress=new_progress)
 
     def get_tv(self):
         """Get related TV instance for a season and create it if it doesn't exist."""
@@ -1830,6 +1828,14 @@ class Episode(models.Model):
                 [self.related_season.related_tv],
                 TV,
                 fields=["status"],
+            )
+
+        # Update season progress to reflect the episode just watched
+        new_progress = self.item.episode_number
+        if self.related_season.progress != new_progress:
+            self.related_season.progress = new_progress
+            Season.objects.filter(pk=self.related_season.pk).update(
+                progress=new_progress
             )
 
 

--- a/src/app/tests/models/test_season.py
+++ b/src/app/tests/models/test_season.py
@@ -30,6 +30,38 @@ class SeasonModel(TestCase):
         self.credentials = {"username": "test", "password": "12345"}
         self.user = get_user_model().objects.create_user(**self.credentials)
 
+        self.episodes_metadata = [
+            {
+                "episode_number": i,
+                "image": f"img{i}.jpg",
+                "air_date": datetime(2023, 1, i, tzinfo=UTC),
+            }
+            for i in range(1, 25)
+        ]
+
+        def mock_metadata(media_type, media_id, source, season_numbers=None, **kw):
+            if media_type == "tv_with_seasons":
+                return {
+                    f"season/{s}": {"episodes": self.episodes_metadata}
+                    for s in (season_numbers or [1])
+                }
+            return {"episodes": self.episodes_metadata, "image": "season_img.jpg"}
+
+        self.metadata_patcher = patch("app.models.providers.services.get_media_metadata")
+        self.mock_get_metadata = self.metadata_patcher.start()
+        self.mock_get_metadata.side_effect = mock_metadata
+        self.addCleanup(self.metadata_patcher.stop)
+
+        tv_item = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Friends",
+            image="http://example.com/image.jpg",
+        )
+        tv = TV(item=tv_item, user=self.user, status=Status.IN_PROGRESS.value)
+        TV.save_base(tv)
+
         item_season = Item.objects.create(
             media_id="1668",
             source=Sources.TMDB.value,
@@ -42,6 +74,7 @@ class SeasonModel(TestCase):
         self.season = Season.objects.create(
             item=item_season,
             user=self.user,
+            related_tv=tv,
             status=Status.IN_PROGRESS.value,
         )
 
@@ -76,7 +109,8 @@ class SeasonModel(TestCase):
         )
 
     def test_season_progress(self):
-        """Test the progress property of the Season model."""
+        """Test that season progress reflects the highest watched episode number."""
+        self.season.refresh_from_db()
         self.assertEqual(self.season.progress, 2)
 
     def test_season_start_date(self):

--- a/src/app/tests/views/test_progress.py
+++ b/src/app/tests/views/test_progress.py
@@ -28,6 +28,16 @@ class ProgressEditSeason(TestCase):
         self.user = get_user_model().objects.create_user(**self.credentials)
         self.client.login(**self.credentials)
 
+        tv_item = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Friends",
+            image="http://example.com/image.jpg",
+        )
+        tv = TV(item=tv_item, user=self.user, status=Status.IN_PROGRESS.value)
+        TV.save_base(tv)
+
         self.item_season = Item.objects.create(
             media_id="1668",
             source=Sources.TMDB.value,
@@ -39,6 +49,7 @@ class ProgressEditSeason(TestCase):
         self.season = Season.objects.create(
             item=self.item_season,
             user=self.user,
+            related_tv=tv,
             status=Status.IN_PROGRESS.value,
         )
 
@@ -57,6 +68,9 @@ class ProgressEditSeason(TestCase):
             end_date=datetime.datetime(2023, 6, 1, 0, 0, tzinfo=datetime.UTC),
         )
         Episode.save_base(episode)
+        # save_base bypasses Episode.save(), so manually set progress
+        Season.objects.filter(pk=self.season.pk).update(progress=1)
+        self.season.refresh_from_db()
 
     def test_progress_increase(self):
         """Test the increase of progress for a season."""
@@ -217,6 +231,9 @@ class ProgressEditPersistentMessages(TestCase):
             end_date=datetime.datetime(2023, 6, 1, 0, 0, tzinfo=datetime.UTC),
         )
         Episode.save_base(episode)
+        # save_base bypasses Episode.save(), so manually set progress
+        Season.objects.filter(pk=self.season.pk).update(progress=1)
+        self.season.refresh_from_db()
 
     @patch("app.models.providers.services.get_media_metadata")
     def test_progress_edit_htmx_appends_persistent_messages(


### PR DESCRIPTION
Implements the suggestion from #1315.

## Changes

- Removes the `Season.progress` `@property` and replaces it with an explicit `PositiveIntegerField` (default `0`)
- When an episode is watched, `Season.progress` is set to that episode's number
- When an episode is unwatched, `Season.progress` is recalculated from the highest remaining watched episode
- When a season or TV show is marked as completed (triggering bulk episode creation), `Season.progress` is updated to the highest episode number created
- Exposes `progress` in `SeasonForm` so users can manually override the value
- Adds a data migration that populates existing rows using the original computed logic (highest-rewatch-count episode for in-progress seasons, highest episode number otherwise)

## Why store it?

Storing the field allows users to manually override the progress value, which is not possible with a computed property.