### PR TITLE
feat: rootless container & small improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,9 @@ ARG VERSION=dev
 ENV VERSION=$VERSION
 
 COPY ./requirements.txt /requirements.txt
-COPY ./entrypoint.sh /entrypoint.sh
 COPY ./supervisord.conf /etc/supervisord.conf
+COPY --chmod=555 ./entrypoint.sh /entrypoint.sh
 COPY ./nginx.conf /etc/nginx/nginx.conf
-# Generate a copy of the nginx config with IPv6 support.
-RUN sed 's/listen 8000;/listen 8000; listen [::]:8000;/' /etc/nginx/nginx.conf > /etc/nginx/nginx.ipv6.conf
 
 WORKDIR /yamtrack
 
@@ -22,15 +20,13 @@ RUN apk add --no-cache nginx shadow \
     && pip install --no-cache-dir supervisor==4.3.0 \
     && rm -rf /root/.cache /tmp/* \
     && find /usr/local -type d -name __pycache__ -exec rm -rf {} + \
-    && chmod +x /entrypoint.sh \
-    # create user abc for later PUID/PGID mapping
-    && useradd -U -M -s /bin/sh abc \
-    # Create required nginx directories and set permissions
-    && mkdir -p /var/log/nginx \
-    && mkdir -p /var/lib/nginx/body
+    && useradd -U -M -u 1000 -s /bin/sh abc \
+    && mkdir -p /yamtrack/db /yamtrack/staticfiles /var/cache/nginx \
+    && chown -R abc:abc /yamtrack/db /yamtrack/staticfiles /var/cache/nginx
 
-# Django app
-COPY src ./
+COPY --chmod=555 --chown=abc:abc src ./
+
+USER abc:abc
 RUN python manage.py collectstatic --noinput
 
 EXPOSE 8000

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,16 +4,4 @@ set -e
 
 python manage.py migrate --noinput
 
-PUID=${PUID:-1000}
-PGID=${PGID:-1000}
-
-groupmod -o -g "$PGID" abc
-usermod -o -u "$PUID" abc
-
-chown abc:abc /yamtrack
-chown -R abc:abc db
-chown -R abc:abc staticfiles
-chown -R abc:abc /var/log/nginx
-chown -R abc:abc /var/lib/nginx
-
 exec /usr/local/bin/supervisord -c /etc/supervisord.conf

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,17 +1,25 @@
-user abc;
-worker_processes auto;
+worker_processes  auto;
+error_log /tmp/error.log;
 pid /tmp/nginx.pid;
-error_log /dev/stderr warn;
 
 events {
-    worker_connections 1024;
+    worker_connections  1024;
 }
 
 http {
+    proxy_temp_path /tmp/proxy_temp;
+    client_body_temp_path /tmp/client_temp;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
+
+    access_log  /tmp/access.log;
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
-
-    access_log /dev/stdout combined;
 
     sendfile on;
     tcp_nodelay on;
@@ -25,9 +33,10 @@ http {
     upstream app_server {
         server 127.0.0.1:8001;
     }
-
+    
     server {
         listen 8000;
+        listen [::]:8000;
         server_name _;
 
         # Security headers
@@ -59,6 +68,5 @@ http {
             expires 30d;
             add_header Cache-Control "public";
         }
-
     }
 }

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -103,6 +103,7 @@ for url in URLS:
 if BASE_URL:
     CSRF_COOKIE_PATH = BASE_URL + "/"
 
+USE_X_FORWARDED_HOST = True
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # Application definition

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,42 +1,22 @@
 [supervisord]
 nodaemon=true
-user=root
+logfile=/tmp/supervisord.conf
 
 [program:nginx]
-command=sh -c 'if [ "${YAMTRACK_IPV6_ENABLED:-False}" = "True" ]; then CONF=/etc/nginx/nginx.ipv6.conf; else CONF=/etc/nginx/nginx.conf; fi; nginx -c $CONF -g "daemon off;"'
-user=root
+command=nginx -c $CONF -g "daemon off;"'
 priority=1
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
 
 [program:gunicorn]
 command=gunicorn --control-socket /tmp/gunicorn.ctl --config python:config.gunicorn config.wsgi:application
-user=abc
 priority=5
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stdout
-stderr_logfile_maxbytes=0
 
 [program:celery]
 command=sh -c 'if [ "${ENV_DEBUG:-False}" = "True" ]; then LOGLEVEL=DEBUG; else LOGLEVEL=INFO; fi; celery --app config worker --loglevel $LOGLEVEL --without-mingle --without-gossip'
-user=abc
 stopasgroup=true
 stopwaitsecs=60
 priority=10
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stdout
-stderr_logfile_maxbytes=0
 
 [program:celery-beat]
 command=sh -c 'if [ "${ENV_DEBUG:-False}" = "True" ]; then LOGLEVEL=DEBUG; else LOGLEVEL=INFO; fi; celery --app config beat --loglevel $LOGLEVEL'
-user=abc
 stopasgroup=true
 priority=15
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stdout
-stderr_logfile_maxbytes=0

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -3,7 +3,7 @@ nodaemon=true
 logfile=/tmp/supervisord.conf
 
 [program:nginx]
-command=nginx -c $CONF -g "daemon off;"'
+command=nginx -c /etc/nginx/nginx.conf -g "daemon off;"
 priority=1
 
 [program:gunicorn]


### PR DESCRIPTION
This PR makes container run as a rootless user by default. Fixes #1120 and replaces PR #1128 

Following files were modified:
- supervisord.conf
- nginx.conf
- Dockerfile
- entrypoint.sh
- /src/config/settings.py

## Changes

Container now runs as user & group `abc:abc` with UID & GID of `1000`, similar to aforementioned PR. It also takes care of permission inside the container, ensuring that abc user can write to directories it needs. All logs get written to `/tmp` as rootless user can't access `/dev/stdout`, `/dev/stderr` - supervisor writes stdout and stderr of apps to `/tmp/appname-stdout---supervisord-randomstring.log` so I suppose it's not that big of an issue.

There's one problem and it's with nginx trying to write an `/var/lib/nginx/logs/error.log` all the time but it just seems to be a hard-coded value and any errors are still logged to supervisord stdout log files if they occur. Since this isn't considered fatal, I see it as a pointless thing to try to fix.

Added `USE_X_FORWARDED_HOST` to `/src/config/settings.py` as otherwise I couldn't get django to trust Caddy's `X Forwarded For` header. This will be more useful for people that will reverse proxy their Yamtrack container to the web and want SSO to work properly. Without it, SSO redirect gets built wrongly and instead of the domain from the headers, it used LAN IP address for redirect, causing invalid callback URL error.

Modified `nginx.conf` to listen on both IPv4 and IPv6 by default. Currently the Dockerfile creates another IPv6 configuration file then uses an undocumented environment variable to switch between them, which seems pointless considering that nginx supports dual-stack connections just fine. Additionally, all relevant temp and log files are written to `/tmp` to allow it to run rootless without barrage of permission errors or having to constantly mount everything to be owned under current user.

entrypoint.sh was reduced to just two simple commands: the simple migration python command and supervisord exec.

`PGID` and `PUID` are unused variables now.

## Potential problems arising from this PR

SQLite installs with bind volumes will need to `chown` their volumes to be owned by rootless user inside container, otherwise they will get either `out of memory` (happens when SQLite can't write to the directory, or to the database), or errors such as `access denied`. User ownership doesn't matter for any other directory as the permissions are allowing enough with them being `r-x`.

## Did you test it?

Yup. It works fine, nothing else to say really.

## What's the benefit?

You can now run the container as any rootless user and as read only, as long as you fix relevant directory ownership yourself. This gets rid of the convenience aspect but in turn it increases security as container init and processes running under it are ran via non-root user with strict permissions that prevent modification to `entrypoint.sh` and anything copied from `/src/*`

If you will be using external database, you can run it as read only easily without suffering through permission errors. Here's my current Quadlet as an example that runs as my user with randomized user namespace and read only.

```bash
[Unit]
Description=Yamtrack - self hosted media tracker for movies, tv shows, anime, manga, video games, books, comics, and board games.
Requires=postgres-yamtrack.service
Requires=valkey-yamtrack.service
After=postgres-yamtrack.service
After=valkey-yamtrack.service

[Install]
WantedBy=default.target

[Service]
Restart=on-failure
SystemCallArchitectures=native
MemoryDenyWriteExecute=false

[Container]
Image=localhost/yamtrack:test
ContainerName=yamtrack
EnvironmentFile=%h/Environments/Yamtrack/.env
AutoUpdate=registry
DropCapability=ALL
NoNewPrivileges=true
ReadOnly=true
Network=Yamtrack.network
# Internal networks
Network=Postgres-Yamtrack.network
Network=Valkey-Yamtrack.network
PublishPort=9103:8000
User=%U:%U
UserNS=auto:size=1002
```

...and no, this wasn't written by LLM before anyone asks.