### PR TITLE
Feat/ttb for games

### DIFF
--- a/src/app/providers/igdb.py
+++ b/src/app/providers/igdb.py
@@ -265,60 +265,15 @@ def search(query, page):
     return data
 
 
-def get_time_to_beat(game_id):
-    """Return time-to-beat data for a game from IGDB."""
-    cache_key = f"ttb_{Sources.IGDB.value}_{game_id}"
-    data = cache.get(cache_key)
-    if data is None:
-        access_token = get_access_token()
-        url = f"{base_url}/game_time_to_beats"
-        query = f"fields hastily, normally, completely; where game_id = {game_id};"
-        headers = {
-            "Client-ID": settings.IGDB_ID,
-            "Authorization": f"Bearer {access_token}",
-        }
-        try:
-            response = services.api_request(
-                Sources.IGDB.value,
-                "POST",
-                url,
-                data=query,
-                headers=headers,
-            )
-        except requests.exceptions.HTTPError as error:
-            error_resp = handle_error(error)
-            if error_resp and error_resp.get("retry"):
-                headers["Authorization"] = f"Bearer {get_access_token()}"
-                response = services.api_request(
-                    Sources.IGDB.value,
-                    "POST",
-                    url,
-                    data=query,
-                    headers=headers,
-                )
-        if response:
-            entry = response[0]
-            data = {
-                stat_name: seconds
-                for stat_name, seconds in entry.items()
-                if stat_name != "id" and seconds is not None
-            }
-            if not data:
-                data = None
-        else:
-            data = None
-        cache.set(cache_key, data)
-    return data
-
-
 def game(media_id):
     """Return the metadata for the selected game from IGDB."""
     cache_key = f"{Sources.IGDB.value}_{MediaTypes.GAME.value}_{media_id}"
     data = cache.get(cache_key)
     if data is None:
         access_token = get_access_token()
-        url = f"{base_url}/games"
-        data = (
+        url = f"{base_url}/multiquery"
+        multiquery = (
+            'query games "GameData" {'
             "fields name,cover.image_id,artworks.image_id,"
             "url,summary,game_type,first_release_date,total_rating,total_rating_count,"
             "genres.name,themes.name,platforms.name,involved_companies.company.name,"
@@ -331,6 +286,11 @@ def game(media_id):
             "similar_games.name,similar_games.cover.image_id,"
             "dlcs.name,dlcs.cover.image_id;"
             f"where id = {media_id};"
+            "};"
+            'query game_time_to_beats "TTBData" {'
+            "fields hastily,normally,completely;"
+            f"where game_id = {media_id};"
+            "};"
         )
         headers = {
             "Client-ID": settings.IGDB_ID,
@@ -342,7 +302,7 @@ def game(media_id):
                 Sources.IGDB.value,
                 "POST",
                 url,
-                data=data,
+                data=multiquery,
                 headers=headers,
             )
         except requests.exceptions.HTTPError as error:
@@ -354,51 +314,61 @@ def game(media_id):
                     Sources.IGDB.value,
                     "POST",
                     url,
-                    data=data,
+                    data=multiquery,
                     headers=headers,
                 )
 
+        results = {item["name"]: item.get("result", []) for item in response}
+
         # Check if response is empty (no results found)
-        if not response:
+        game_results = results.get("GameData", [])
+        if not game_results:
             services.raise_not_found_error(
                 Sources.IGDB.value,
                 media_id,
                 "game",
             )
+        game_response = game_results[0]  # response is a list with a single element
 
-        response = response[0]  # response is a list with a single element
+        ttb_results = results.get("TTBData", [])
+        time_to_beat = None
+        if ttb_results:
+            entry = ttb_results[0]  # response is a list with a single element
+            ttb_data = {k: v for k, v in entry.items() if k != "id" and v is not None}
+            time_to_beat = ttb_data or None
+
         data = {
-            "media_id": response["id"],
+            "media_id": game_response["id"],
             "source": Sources.IGDB.value,
-            "source_url": response["url"],
+            "source_url": game_response["url"],
             "media_type": MediaTypes.GAME.value,
-            "title": response["name"],
+            "title": game_response["name"],
             "max_progress": None,
-            "image": get_image_url(response),
-            "synopsis": response.get("summary", "No synopsis available."),
-            "genres": get_list(response, "genres"),
-            "score": get_score(response),
-            "score_count": response.get("total_rating_count"),
+            "image": get_image_url(game_response),
+            "synopsis": game_response.get("summary", "No synopsis available."),
+            "genres": get_list(game_response, "genres"),
+            "score": get_score(game_response),
+            "score_count": game_response.get("total_rating_count"),
             "details": {
-                "format": get_game_type(response["game_type"]),
-                "release_date": get_start_date(response),
-                "themes": get_list(response, "themes"),
-                "platforms": get_list(response, "platforms"),
-                "companies": get_companies(response),
+                "format": get_game_type(game_response["game_type"]),
+                "release_date": get_start_date(game_response),
+                "themes": get_list(game_response, "themes"),
+                "platforms": get_list(game_response, "platforms"),
+                "companies": get_companies(game_response),
             },
             "related": {
-                "parent_game": get_parent(response.get("parent_game")),
-                "remasters": get_related(response.get("remasters")),
-                "remakes": get_related(response.get("remakes")),
-                "expansions": get_related(response.get("expansions")),
-                "dlcs": get_related(response.get("dlcs")),
+                "parent_game": get_parent(game_response.get("parent_game")),
+                "remasters": get_related(game_response.get("remasters")),
+                "remakes": get_related(game_response.get("remakes")),
+                "expansions": get_related(game_response.get("expansions")),
+                "dlcs": get_related(game_response.get("dlcs")),
                 "standalone_expansions": get_related(
-                    response.get("standalone_expansions"),
+                    game_response.get("standalone_expansions"),
                 ),
-                "expanded_games": get_related(response.get("expanded_games")),
-                "recommendations": get_related(response.get("similar_games")),
+                "expanded_games": get_related(game_response.get("expanded_games")),
+                "recommendations": get_related(game_response.get("similar_games")),
             },
-            "time_to_beat": get_time_to_beat(response["id"]),
+            "time_to_beat": time_to_beat,
         }
         cache.set(cache_key, data)
     return data

--- a/src/app/providers/igdb.py
+++ b/src/app/providers/igdb.py
@@ -265,6 +265,52 @@ def search(query, page):
     return data
 
 
+def get_time_to_beat(game_id):
+    """Return time-to-beat data for a game from IGDB."""
+    cache_key = f"ttb_{Sources.IGDB.value}_{game_id}"
+    data = cache.get(cache_key)
+    if data is None:
+        access_token = get_access_token()
+        url = f"{base_url}/game_time_to_beats"
+        query = f"fields hastily, normally, completely; where game_id = {game_id};"
+        headers = {
+            "Client-ID": settings.IGDB_ID,
+            "Authorization": f"Bearer {access_token}",
+        }
+        try:
+            response = services.api_request(
+                Sources.IGDB.value,
+                "POST",
+                url,
+                data=query,
+                headers=headers,
+            )
+        except requests.exceptions.HTTPError as error:
+            error_resp = handle_error(error)
+            if error_resp and error_resp.get("retry"):
+                headers["Authorization"] = f"Bearer {get_access_token()}"
+                response = services.api_request(
+                    Sources.IGDB.value,
+                    "POST",
+                    url,
+                    data=query,
+                    headers=headers,
+                )
+        if response:
+            entry = response[0]
+            data = {
+                stat_name: seconds
+                for stat_name, seconds in entry.items()
+                if stat_name != "id" and seconds is not None
+            }
+            if not data:
+                data = None
+        else:
+            data = None
+        cache.set(cache_key, data)
+    return data
+
+
 def game(media_id):
     """Return the metadata for the selected game from IGDB."""
     cache_key = f"{Sources.IGDB.value}_{MediaTypes.GAME.value}_{media_id}"
@@ -352,6 +398,7 @@ def game(media_id):
                 "expanded_games": get_related(response.get("expanded_games")),
                 "recommendations": get_related(response.get("similar_games")),
             },
+            "time_to_beat": get_time_to_beat(response["id"]),
         }
         cache.set(cache_key, data)
     return data

--- a/src/app/templatetags/app_tags.py
+++ b/src/app/templatetags/app_tags.py
@@ -453,19 +453,18 @@ def show_media_score(rating, user):
 
 @register.filter
 def seconds_to_duration(seconds):
-    """Convert seconds to human-readable duration, rounded to nearest 30 min."""
+    """Convert seconds to human-readable duration.
+
+    Under 30 min: rounds to nearest 5 min. 30 min and above: rounds to nearest 30 min.
+    """
     if not seconds:
         return None
     total_minutes = seconds // 60
+    if total_minutes < 30:  # noqa: PLR2004
+        return f"{max(5, round(total_minutes / 5) * 5)}m"
     hours, minutes = divmod(total_minutes, 60)
-    match hours, minutes:
-        case (0, m) if m < 45:  # noqa: PLR2004
-            return "30m"
-        case (0, _):
-            return "1h"
-        case (h, m) if m < 15:  # noqa: PLR2004
-            return f"{h}h"
-        case (h, m) if m >= 45:  # noqa: PLR2004
-            return f"{h + 1}h"
-        case (h, _):
-            return f"{h}h 30m"
+    if hours == 0:
+        return "30m" if minutes < 45 else "1h"  # noqa: PLR2004
+    if minutes >= 45:  # noqa: PLR2004
+        return f"{hours + 1}h"
+    return f"{hours}h" if minutes < 15 else f"{hours}h 30m"  # noqa: PLR2004

--- a/src/app/templatetags/app_tags.py
+++ b/src/app/templatetags/app_tags.py
@@ -449,3 +449,23 @@ def show_media_score(rating, user):
         True if we should show the media score
     """
     return rating is not None and (not user.hide_zero_rating or rating > 0)
+
+
+@register.filter
+def seconds_to_duration(seconds):
+    """Convert seconds to human-readable duration, rounded to nearest 30 min."""
+    if not seconds:
+        return None
+    total_minutes = seconds // 60
+    hours, minutes = divmod(total_minutes, 60)
+    match hours, minutes:
+        case (0, m) if m < 45:  # noqa: PLR2004
+            return "30m"
+        case (0, _):
+            return "1h"
+        case (h, m) if m < 15:  # noqa: PLR2004
+            return f"{h}h"
+        case (h, m) if m >= 45:  # noqa: PLR2004
+            return f"{h + 1}h"
+        case (h, _):
+            return f"{h}h 30m"

--- a/src/app/tests/providers/test_metadata.py
+++ b/src/app/tests/providers/test_metadata.py
@@ -342,6 +342,12 @@ class Metadata(TestCase):
             response["details"]["themes"],
             ["Action", "Fantasy", "Open world"],
         )
+        self.assertIsNotNone(response["time_to_beat"])
+        self.assertIn("normally", response["time_to_beat"])
+        self.assertEqual(
+            list(response["time_to_beat"].keys()),
+            ["hastily", "normally", "completely"],
+        )
 
     def test_external_game_steam(self):
         """Test the external_game method for Steam games."""

--- a/src/app/tests/test_templatetags.py
+++ b/src/app/tests/test_templatetags.py
@@ -379,3 +379,23 @@ class AppTagsTests(TestCase):
         self.assertTrue(app_tags.show_media_score(1, mock_user_hide))
         self.assertFalse(app_tags.show_media_score(0, mock_user_hide))
         self.assertFalse(app_tags.show_media_score(None, mock_user_hide))
+
+    def test_seconds_to_duration(self):
+        """Test conversion of seconds to human-readable duration, rounded to 30 min."""
+        self.assertIsNone(app_tags.seconds_to_duration(None))
+        self.assertIsNone(app_tags.seconds_to_duration(0))
+
+        cases = [
+            (5 * 60, "30m"),  # 5m -> 30m
+            (30 * 60, "30m"),  # exactly 30m
+            (40 * 60, "30m"),  # 40m -> 30m (< 45m)
+            (45 * 60, "1h"),  # 45m -> 1h
+            (60 * 60, "1h"),  # exactly 1h
+            (65 * 60, "1h"),  # 1h 5m -> 1h
+            (75 * 60, "1h 30m"),  # 1h 15m -> 1h 30m
+            (90 * 60, "1h 30m"),  # exactly 1h 30m
+            (105 * 60, "2h"),  # 1h 45m -> 2h
+        ]
+        for seconds, expected in cases:
+            with self.subTest(seconds=seconds):
+                self.assertEqual(app_tags.seconds_to_duration(seconds), expected)

--- a/src/app/tests/test_templatetags.py
+++ b/src/app/tests/test_templatetags.py
@@ -381,12 +381,20 @@ class AppTagsTests(TestCase):
         self.assertFalse(app_tags.show_media_score(None, mock_user_hide))
 
     def test_seconds_to_duration(self):
-        """Test conversion of seconds to human-readable duration, rounded to 30 min."""
+        """Test conversion of seconds to human-readable duration."""
         self.assertIsNone(app_tags.seconds_to_duration(None))
         self.assertIsNone(app_tags.seconds_to_duration(0))
 
         cases = [
-            (5 * 60, "30m"),  # 5m -> 30m
+            (5 * 60, "5m"),  # exactly 5m
+            (10 * 60, "10m"),  # exactly 10m
+            (12 * 60, "10m"),  # 12m -> 10m (< 13m)
+            (13 * 60, "15m"),  # 13m -> 15m
+            (15 * 60, "15m"),  # exactly 15m
+            (20 * 60, "20m"),  # exactly 20m
+            (25 * 60, "25m"),  # exactly 25m
+            (27 * 60, "25m"),  # 27m -> 25m (< 28m)
+            (28 * 60, "30m"),  # 28m -> 30m
             (30 * 60, "30m"),  # exactly 30m
             (40 * 60, "30m"),  # 40m -> 30m (< 45m)
             (45 * 60, "1h"),  # 45m -> 1h

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -224,7 +224,7 @@ CACHES = {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": REDIS_URL,
         "TIMEOUT": CACHE_TIMEOUT,
-        "VERSION": 15,
+        "VERSION": 16,
         "KEY_PREFIX": KEY_PREFIX,
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",

--- a/src/templates/app/media_details.html
+++ b/src/templates/app/media_details.html
@@ -492,6 +492,29 @@
           <div class="text-gray-200">No details available</div>
         {% endif %}
       </div>
+      {% if media.time_to_beat %}
+        <div class="bg-[#2a2f35] p-4 rounded-lg text-center md:text-start mt-4">
+          <h3 class="text-sm font-semibold text-gray-400 mb-4">TIME TO BEAT</h3>
+          {% if media.time_to_beat.hastily %}
+            <div class="mb-4">
+              <h3 class="text-sm font-semibold text-gray-400">HASTILY</h3>
+              <p class="text-gray-200">{{ media.time_to_beat.hastily|seconds_to_duration }}</p>
+            </div>
+          {% endif %}
+          {% if media.time_to_beat.normally %}
+            <div class="mb-4">
+              <h3 class="text-sm font-semibold text-gray-400">NORMALLY</h3>
+              <p class="text-gray-200">{{ media.time_to_beat.normally|seconds_to_duration }}</p>
+            </div>
+          {% endif %}
+          {% if media.time_to_beat.completely %}
+            <div>
+              <h3 class="text-sm font-semibold text-gray-400">COMPLETELY</h3>
+              <p class="text-gray-200">{{ media.time_to_beat.completely|seconds_to_duration }}</p>
+            </div>
+          {% endif %}
+        </div>
+      {% endif %}
     </div>
 
     <div class="w-full md:w-3/4">


### PR DESCRIPTION
## Summary

Adds "Time to Beat" statistics to IGDB game detail pages, similar to [HowLongToBeat.com](https://howlongtobeat.com/). Resolves issue #1380 

- Fetches `hastily` / `normally` / `completely` fields from the IGDB `game_time_to_beats` endpoint and caches the result alongside other game metadata
- Adds a `seconds_to_duration` template filter that converts seconds to a human-readable string (e.g. `"1h 30m"`), rounded to the nearest 30 minutes
- Displays a "Time to Beat" card in the left sidebar of the game details page when data is available

## Changes by files

- **`app/providers/igdb.py`** — new `get_time_to_beat(game_id)` helper; `game()` now includes a `time_to_beat` key
- **`app/templatetags/app_tags.py`** — new `seconds_to_duration` filter
- **`templates/app/media_details.html`** — TTB card in the left sidebar (game only, hidden when no data)
- **`app/tests/`** — tests for `seconds_to_duration` rounding logic and `time_to_beat` presence in metadata response

## How to test

- [ ] Open a game detail page for a well-known game (e.g. The Witcher 3, IGDB ID 1942) — TTB card should appear in the left sidebar
- [ ] Open a game with no TTB data — card should not appear
- [ ] Run `pytest app/tests/test_templatetags.py::AppTagsTests::test_seconds_to_duration`
- [ ] Run `pytest app/tests/providers/test_metadata.py::Metadata::test_games`