### PR TITLE
Add support for X-Forwarded-* headers for better reverse proxy support.

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -103,8 +103,11 @@ for url in URLS:
 if BASE_URL:
     CSRF_COOKIE_PATH = BASE_URL + "/"
 
-SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
-USE_X_FORWARDED_HOST = config("USE_X_FORWARDED_HOST", default=False, cast=bool)
+USE_X_FORWARDED = config("USE_X_FORWARDED", default=False, cast=bool)
+
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https") if (config("USE_X_FORWARDED_PROTO", default=USE_X_FORWARDED, cast=bool)) else None
+USE_X_FORWARDED_HOST = config("USE_X_FORWARDED_HOST", default=USE_X_FORWARDED, cast=bool)
+USE_X_FORWARDED_PORT = config("USE_X_FORWARDED_PORT", default=USE_X_FORWARDED, cast=bool)
 
 # Application definition
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -104,6 +104,7 @@ if BASE_URL:
     CSRF_COOKIE_PATH = BASE_URL + "/"
 
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+USE_X_FORWARDED_HOST = config("USE_X_FORWARDED_HOST", default=False, cast=bool)
 
 # Application definition
 


### PR DESCRIPTION
Solves #1023 in a better way than #1327 that also works in other imports, without the security problem of spoofing possibility, by having the user only enable it when Yamtrack is used behind another reverse proxy.