### PR TITLE
fix: preserve multiline notes in Yamtrack CSV import

### DIFF
--- a/src/integrations/imports/yamtrack.py
+++ b/src/integrations/imports/yamtrack.py
@@ -1,6 +1,7 @@
 import logging
 from collections import defaultdict
 from csv import DictReader
+from io import StringIO
 
 from django.apps import apps
 from django.conf import settings
@@ -57,12 +58,12 @@ class YamtrackImporter:
     def import_data(self):
         """Import all user data from the CSV file."""
         try:
-            decoded_file = self.file.read().decode("utf-8").splitlines()
+            decoded_file = self.file.read().decode("utf-8")
         except UnicodeDecodeError as e:
             msg = "Invalid file format. Please upload a CSV file."
             raise MediaImportError(msg) from e
 
-        reader = DictReader(decoded_file)
+        reader = DictReader(StringIO(decoded_file, newline=""))
 
         for row in reader:
             try:

--- a/src/integrations/tests/imports/test_yamtrack.py
+++ b/src/integrations/tests/imports/test_yamtrack.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from io import BytesIO
 from pathlib import Path
 
 from django.contrib.auth import get_user_model
@@ -67,6 +68,18 @@ class ImportYamtrack(TestCase):
             tv.history.first().history_date,
             datetime(2024, 2, 9, 12, 0, 0, tzinfo=UTC),
         )
+
+    def test_multiline_notes_are_preserved(self):
+        """Test that quoted multiline notes keep embedded newlines."""
+        csv_content = b""""media_id","source","media_type","title","image","season_number","episode_number","score","status","notes","start_date","end_date","progress","created_at","progressed_at"
+"123192","tmdb","tv","The Crowded Room","https://image.tmdb.org/t/p/w500/vRmopCFp0j1eJGbILLsYsYzxmL8.jpg","","","","Completed","test
+test","2026-05-14 11:09:00+00:00","2026-05-14 11:09:00+00:00","10","2026-05-14 11:09:26.617144+00:00","2026-05-14 11:09:00+00:00"
+"""  # noqa: E501
+
+        yamtrack.importer(BytesIO(csv_content), self.user, "new")
+
+        tv = TV.objects.get(user=self.user, item__media_id="123192")
+        self.assertEqual(tv.notes, "test\ntest")
 
     def test_missing_metadata_handling(self):
         """Test _handle_missing_metadata method directly."""


### PR DESCRIPTION
Export already handles them correctly adding a new line into the quoted notes.

```csv
"media_id","source","media_type","title","image","season_number","episode_number","score","status","notes","start_date","end_date","progress","created_at","progressed_at"
"123192","tmdb","tv","The Crowded Room","https://image.tmdb.org/t/p/w500/vRmopCFp0j1eJGbILLsYsYzxmL8.jpg","","","","Completed","test
test","2026-05-14 11:09:00+00:00","2026-05-14 11:09:00+00:00","10","2026-05-14 11:09:26.617144+00:00","2026-05-14 11:09:00+00:00"
```

The missing piece was import as it ignores these new lines.

This change should prevent custom line splitting and push this decision making into CSV library to handle.

Fixes https://github.com/FuzzyGrim/Yamtrack/issues/1419

For future - other imports also do the same thing. They may also need fixing.