### PR TITLE
feat: add notes to individual episodes

### DIFF
--- a/src/app/forms.py
+++ b/src/app/forms.py
@@ -364,9 +364,12 @@ class EpisodeForm(forms.ModelForm):
         """Bind form to model."""
 
         model = Episode
-        fields = ("end_date",)
+        fields = ("end_date", "notes")
         widgets = {
             "end_date": forms.DateInput(attrs={"type": "date"}),
+            "notes": forms.Textarea(
+                attrs={"placeholder": "Add any notes or comments...", "rows": "3"},
+            ),
         }
 
     def __init__(self, *args, **kwargs):

--- a/src/app/migrations/0062_add_episode_notes.py
+++ b/src/app/migrations/0062_add_episode_notes.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Add notes support to episode watches and their history."""
+
+    dependencies = [
+        ("app", "0061_episode_item_not_null"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="episode",
+            name="notes",
+            field=models.TextField(blank=True, default=""),
+        ),
+        migrations.AddField(
+            model_name="historicalepisode",
+            name="notes",
+            field=models.TextField(blank=True, default=""),
+        ),
+    ]

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -1568,7 +1568,7 @@ class Season(Media):
         else:
             logger.info("No more episodes to watch.")
 
-    def watch(self, episode_number, end_date):
+    def watch(self, episode_number, end_date, notes=""):
         """Create or add a repeat to an episode of the season."""
         item = self.get_episode_item(episode_number)
 
@@ -1576,6 +1576,7 @@ class Season(Media):
             related_season=self,
             item=item,
             end_date=end_date,
+            notes=notes,
         )
         logger.info(
             "%s created successfully.",
@@ -1759,6 +1760,7 @@ class Episode(models.Model):
         related_name="episodes",
     )
     end_date = models.DateTimeField(null=True, blank=True)
+    notes = models.TextField(blank=True, default="")
 
     class Meta:
         """Meta options for the model."""

--- a/src/app/tests/test_forms.py
+++ b/src/app/tests/test_forms.py
@@ -97,6 +97,7 @@ class BasicMediaForm(TestCase):
         """Test the episode form with valid data."""
         form_data = {
             "end_date": "2023-06-01",
+            "notes": "Great episode",
         }
         form = EpisodeForm(data=form_data)
         self.assertTrue(form.is_valid())
@@ -105,6 +106,7 @@ class BasicMediaForm(TestCase):
         """Test the episode form with valid data."""
         form_data = {
             "end_date": "2023-06-01T12:00:00Z",
+            "notes": "Great episode",
         }
         form = EpisodeForm(data=form_data)
         self.assertTrue(form.is_valid())

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -708,7 +708,11 @@ def episode_save(request):
 
         logger.info("%s did not exist, it was created successfully.", related_season)
 
-    related_season.watch(episode_number, form.cleaned_data["end_date"])
+    related_season.watch(
+        episode_number,
+        form.cleaned_data["end_date"],
+        form.cleaned_data["notes"],
+    )
 
     return helpers.redirect_back(request)
 

--- a/src/integrations/tests/test_exports.py
+++ b/src/integrations/tests/test_exports.py
@@ -78,6 +78,7 @@ class ExportCSVTest(TestCase):
             item=item_episode,
             related_season=season,
             end_date=datetime(2023, 6, 1, 0, 0, tzinfo=UTC),
+            notes="Favorite episode",
         )
 
         item_anime = Item.objects.create(
@@ -174,3 +175,5 @@ class ExportCSVTest(TestCase):
         for row in reader:
             media_id = row["media_id"]
             self.assertIn(media_id, db_media_ids)
+            if row["media_type"] == MediaTypes.EPISODE.value:
+                self.assertEqual(row["notes"], "Favorite episode")

--- a/src/templates/app/components/fill_track_episode.html
+++ b/src/templates/app/components/fill_track_episode.html
@@ -45,11 +45,14 @@
             {% for entry in episode.history %}
               <div class="flex items-center justify-between bg-[#343a40] rounded-md p-3 border border-gray-600">
                 <div class="text-sm text-white">
-                  {% if entry.end_date %}
-                    {{ entry.end_date|datetime_format:request.user }}
-                  {% else %}
-                    No date provided
-                  {% endif %}
+                  <div>
+                    {% if entry.end_date %}
+                      {{ entry.end_date|datetime_format:request.user }}
+                    {% else %}
+                      No date provided
+                    {% endif %}
+                  </div>
+                  {% if entry.notes %}<p class="mt-1 text-xs text-gray-300 italic">"{{ entry.notes|linebreaksbr }}"</p>{% endif %}
                 </div>
                 <form method="post"
                       action="{% url 'media_delete' %}?next={{ request.path }}">
@@ -100,6 +103,16 @@
                  @focus="if (!pointerOnPickerIcon) { $el.showPicker?.() }"
                  @click="pointerOnPickerIcon = false"
                  x-model="inputDateTime">
+        </div>
+
+        <div class="mt-4">
+          <label class="block text-sm font-medium text-gray-300 mb-2"
+                 for="episode-notes-{{ episode.episode_number }}">Notes</label>
+          <textarea class="w-full p-3 bg-[#343a40] rounded-md text-white border border-gray-600 focus:outline-none focus:ring-2 focus:ring-[#4a9eff]"
+                    id="episode-notes-{{ episode.episode_number }}"
+                    rows="3"
+                    name="notes"
+                    placeholder="Add any notes or comments..."></textarea>
         </div>
 
         {# Submit Area #}


### PR DESCRIPTION
Expand existing notes on shows/movies/... onto episodes. Not a lot of changes required as this was mostly already prepared just not exposed onto the episode items. CSV imports/exports also work with no changes as they already had empty notes field. Just a migration was needed to add the notes column.

This was something I used on Trakt was surprised this did not migrate or even exist.

Related to https://github.com/FuzzyGrim/Yamtrack/issues/570 https://github.com/FuzzyGrim/Yamtrack/issues/676

## UI

Maybe use 2 rows? As you prefer so it does not disrupt the modal too much.

For the future - maybe editing watches as now once note is added if a user wanted to edit the note he would have to remove and re-add the watch.

<img height="500" alt="Screenshot 2026-05-15 at 9 31 34 PM" src="https://github.com/user-attachments/assets/08d7c406-be1a-4264-8678-1a0fc4d5415e" />
<img height="500" alt="Screenshot 2026-05-15 at 9 31 55 PM" src="https://github.com/user-attachments/assets/ca09c812-4385-4553-979c-3ffbd79e5069" />