### PR TITLE
Fix calendar reload skipping seasons with new TMDB episodes

### DIFF
--- a/src/events/calendar/tv.py
+++ b/src/events/calendar/tv.py
@@ -73,12 +73,24 @@ def get_seasons_to_process(tv_item):
         item__media_type=MediaTypes.SEASON.value,
     ).select_related("item")
 
-    seasons_with_events = {event.item.season_number for event in existing_season_events}
+    events_per_season = {}
+    seasons_with_events = set()
+    for event in existing_season_events:
+        sn = event.item.season_number
+        seasons_with_events.add(sn)
+        events_per_season[sn] = events_per_season.get(sn, 0) + 1
+
+    tmdb_episode_count = {
+        season["season_number"]: season.get("max_progress", 0)
+        for season in tv_metadata["related"]["seasons"]
+    }
+
     seasons_to_process = [
         season_num
         for season_num in season_numbers
         if season_num not in seasons_with_events
         or (next_episode_season and season_num >= next_episode_season)
+        or events_per_season.get(season_num, 0) < tmdb_episode_count.get(season_num, 0)
     ]
 
     if not seasons_to_process:

--- a/src/events/calendar/tv.py
+++ b/src/events/calendar/tv.py
@@ -75,8 +75,7 @@ def get_seasons_to_process(tv_item):
 
     events_per_season = {}
     seasons_with_events = set()
-    for event in existing_season_events:
-        sn = event.item.season_number
+    for sn in existing_season_events.values_list("item__season_number", flat=True):
         seasons_with_events.add(sn)
         events_per_season[sn] = events_per_season.get(sn, 0) + 1
 

--- a/src/events/tests/calendar/test_tv.py
+++ b/src/events/tests/calendar/test_tv.py
@@ -299,6 +299,50 @@ class CalendarTVTests(CalendarFixturesMixin, TestCase):
 
         self.assertEqual(get_seasons_to_process(self.tv_item), [])
 
+    @patch("events.calendar.tv.tmdb.tv")
+    def test_get_seasons_to_process_includes_seasons_with_new_tmdb_episodes(
+        self, mock_tv
+    ):
+        """Seasons with fewer events than TMDB episode count should be re-processed."""
+        mock_tv.return_value = {
+            "related": {
+                "seasons": [
+                    # Season 0: TMDB has 2 episodes, we have 1 event → needs refresh
+                    {"season_number": 0, "max_progress": 2},
+                    # Season 1: TMDB has 1 episode, we have 1 event → up to date
+                    {"season_number": 1, "max_progress": 1},
+                    # Season 2: upcoming → always processed
+                    {"season_number": 2, "max_progress": 0},
+                ],
+            },
+            "next_episode_season": 2,
+        }
+        Event.objects.create(
+            item=self.season_item,  # season_number=1
+            content_number=1,
+            datetime=datetime.datetime(2020, 1, 1, tzinfo=ZoneInfo("UTC")),
+        )
+        season_0_item, _ = Item.objects.get_or_create(
+            media_id=self.tv_item.media_id,
+            source=self.tv_item.source,
+            media_type="season",
+            season_number=0,
+            defaults={"title": self.tv_item.title, "image": ""},
+        )
+        Event.objects.create(
+            item=season_0_item,
+            content_number=1,
+            datetime=datetime.datetime(2019, 1, 1, tzinfo=ZoneInfo("UTC")),
+        )
+
+        result = get_seasons_to_process(self.tv_item)
+
+        # Season 0 (new TMDB episode) and season 2 (upcoming) should be processed
+        self.assertIn(0, result)
+        self.assertIn(2, result)
+        # Season 1 is up to date
+        self.assertNotIn(1, result)
+
     @patch("events.calendar.tv.get_seasons_to_process")
     def test_process_tv_returns_when_no_seasons_need_processing(
         self,


### PR DESCRIPTION
When a season already had events, the calendar reload only re-processed it if its season number was >= next_episode_season. This meant seasons with a lower number (e.g. Season 0 specials) were permanently skipped once initially populated, even when TMDB later added new episodes.

Fix by adding a third condition: also re-process any season where the number of existing events is fewer than TMDB's reported episode count. This is safe because save_events uses an upsert, so re-processing is always idempotent.

Fixes #1428