### PR TITLE
Fall back to TV show image when season image is missing

### DIFF
--- a/src/app/providers/tmdb.py
+++ b/src/app/providers/tmdb.py
@@ -280,6 +280,9 @@ def enrich_season_with_tv_data(season_data, tv_data, media_id, season_number):
     season_data["genres"] = tv_data["genres"]
     if season_data["synopsis"] == "No synopsis available.":
         season_data["synopsis"] = tv_data["synopsis"]
+    # Fallback to the TV show image when the season has no image of its own
+    if season_data["image"] == settings.IMG_NONE:
+        season_data["image"] = tv_data["image"]
     return season_data
 
 
@@ -627,6 +630,9 @@ def get_related(related_medias, media_type, parent_response=None):
             "image": get_image_url(media["poster_path"]),
         }
         if media_type == MediaTypes.SEASON.value:
+            # Fallback to the TV show image when the season has no image of its own
+            if data["image"] == settings.IMG_NONE:
+                data["image"] = get_image_url(parent_response["poster_path"])
             data["media_id"] = parent_response["id"]
             data["title"] = parent_response["name"]
             data["season_number"] = media["season_number"]

--- a/src/app/tests/providers/test_metadata.py
+++ b/src/app/tests/providers/test_metadata.py
@@ -293,6 +293,73 @@ class Metadata(TestCase):
 
         mock_tv_with_seasons.assert_called_with("1396", ["1"])
 
+    def test_tmdb_season_image_falls_back_to_tv_image(self):
+        """A season with no image inherits the parent TV show's image."""
+        season_data = {
+            "synopsis": "Season synopsis.",
+            "image": settings.IMG_NONE,
+        }
+        tv_data = {
+            "title": "Test Show",
+            "tvdb_id": 42,
+            "external_links": {},
+            "genres": ["Drama"],
+            "synopsis": "Show synopsis.",
+            "image": "https://image.tmdb.org/t/p/w500/show.jpg",
+        }
+
+        enriched = tmdb.enrich_season_with_tv_data(season_data, tv_data, "1396", 1)
+
+        self.assertEqual(enriched["image"], "https://image.tmdb.org/t/p/w500/show.jpg")
+
+    def test_tmdb_season_image_preserved_when_present(self):
+        """A season with its own image keeps it instead of using the TV image."""
+        season_data = {
+            "synopsis": "Season synopsis.",
+            "image": "https://image.tmdb.org/t/p/w500/season.jpg",
+        }
+        tv_data = {
+            "title": "Test Show",
+            "tvdb_id": 42,
+            "external_links": {},
+            "genres": ["Drama"],
+            "synopsis": "Show synopsis.",
+            "image": "https://image.tmdb.org/t/p/w500/show.jpg",
+        }
+
+        enriched = tmdb.enrich_season_with_tv_data(season_data, tv_data, "1396", 1)
+
+        self.assertEqual(
+            enriched["image"],
+            "https://image.tmdb.org/t/p/w500/season.jpg",
+        )
+
+    def test_tmdb_get_related_season_image_fallback(self):
+        """Related seasons with no image inherit the parent TV show's image."""
+        related_medias = [
+            {
+                "poster_path": None,
+                "season_number": 1,
+                "name": "Season 1",
+                "air_date": "2020-01-01",
+                "episode_count": 10,
+            }
+        ]
+        parent_response = {
+            "id": 123,
+            "name": "Test Show",
+            "poster_path": "/show.jpg",
+        }
+
+        related = tmdb.get_related(
+            related_medias, MediaTypes.SEASON.value, parent_response
+        )
+
+        self.assertEqual(len(related), 1)
+        self.assertEqual(
+            related[0]["image"], "https://image.tmdb.org/t/p/w500/show.jpg"
+        )
+
     def test_tmdb_find_next_episode(self):
         """Test the find_next_episode function."""
         episodes_metadata = [


### PR DESCRIPTION
When TMDB does not return a poster path for a season, the season image is set to the placeholder `IMG_NONE`. This change makes `enrich_season_with_tv_data` substitute the parent TV show's image in that case, so seasons that lack their own art render the show's poster instead of the placeholder.

Since enrichment runs whenever season metadata is fetched/cached via `tv_with_seasons`, all downstream consumers (views, models, calendar, webhooks, imports) inherit the fallback automatically.

Added unit tests covering both the fallback case and the case where the season already has its own image.