### PR TITLE
Fix build-docs workflow: use concrete Python version

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -22,7 +22,7 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
       - uses: astral-sh/setup-uv@v7
         with:
-          python-version: 3.x
+          python-version: "3.12"
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
The `build-docs` workflow is failing on `dev` (e.g. [run 25991535613](https://github.com/FuzzyGrim/Yamtrack/actions/runs/25991535613/job/76398459237)) with:

```
error: No interpreter found for executable name `3.x` in managed installations or search path
```

`astral-sh/setup-uv` passes `python-version` through as `UV_PYTHON`, and `uv` does not accept the `3.x` wildcard that `actions/setup-python` supports — it requires a concrete version.

Pinned to `3.12` to match `requires-python = ">=3.12"` in `pyproject.toml` and the version already used in `app-tests.yml`.