### PR TITLE
Update documentation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Yamtrack is a self hosted media tracker for movies, tv shows, anime, manga, vide
 
 ## 📚 Documentation
 
-The full documentation is available at [https://66bunz.github.io/Yamtrack/](https://66bunz.github.io/Yamtrack/).
+The full documentation is available at [66bunz.github.io/Yamtrack/](https://66bunz.github.io/Yamtrack/).
 
 <!-- --8<-- [start:docs-index-body] -->
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Yamtrack is a self hosted media tracker for movies, tv shows, anime, manga, vide
 
 ## 📚 Documentation
 
-The full documentation is available at [fuzzygrim.github.io/Yamtrack](https://fuzzygrim.github.io/Yamtrack/).
+The full documentation is available at [https://66bunz.github.io/Yamtrack/](https://66bunz.github.io/Yamtrack/).
 
 <!-- --8<-- [start:docs-index-body] -->
 


### PR DESCRIPTION
Updated the documentation link in the README.md because the provided link is not working. The link to the documentation is from a simple online search.

I apology in advanced when that was intentional and a Documentation is soon to come under the original link. ^^ 