### PR TITLE
feat: show movie/show release year under title in TMDB media search

### DIFF
--- a/src/app/providers/tmdb.py
+++ b/src/app/providers/tmdb.py
@@ -104,6 +104,7 @@ def search(media_type, query, page):
                 "media_type": media_type,
                 "title": get_title(media),
                 "image": get_image_url(media["poster_path"]),
+                "release_year": get_release_year(media_type, media),
             }
             for media in response["results"]
         ]
@@ -525,6 +526,23 @@ def get_title(response):
         return response["title"]
     except KeyError:
         return response["name"]
+
+
+def get_release_year(media_type, response):
+    """Return the release year for the media."""
+    date_str = None
+    if media_type == MediaTypes.TV.value:
+        date_str = response["first_air_date"]
+    elif media_type == MediaTypes.MOVIE.value:
+        date_str = response["release_date"]
+
+    if date_str:
+        try:
+            return int(date_str[:4])
+        except ValueError:
+            pass
+
+    return None
 
 
 def get_start_date(date):

--- a/src/app/tests/providers/test_search.py
+++ b/src/app/tests/providers/test_search.py
@@ -16,6 +16,9 @@ from app.providers import (
 
 mock_path = Path(__file__).resolve().parent.parent / "mock_data"
 
+BREAKING_BAD_TMDB_ID = 1396
+THE_MATRIX_TMDB_ID = 603
+
 
 class Search(TestCase):
     """Test the external API calls for media search."""
@@ -65,6 +68,29 @@ class Search(TestCase):
 
         for tv in response["results"]:
             self.assertTrue(all(key in tv for key in required_keys))
+
+        breaking_bad = next(
+            tv for tv in response["results"] if tv["media_id"] == BREAKING_BAD_TMDB_ID
+        )
+        self.assertEqual(breaking_bad["release_year"], 2008)
+
+    def test_movie(self):
+        """Test the search method for movies.
+
+        Assert that all required keys are present in each entry.
+        """
+        response = tmdb.search(MediaTypes.MOVIE.value, "The Matrix", 1)
+        required_keys = {"media_id", "media_type", "title", "image"}
+
+        for movie in response["results"]:
+            self.assertTrue(all(key in movie for key in required_keys))
+
+        the_matrix = next(
+            movie
+            for movie in response["results"]
+            if movie["media_id"] == THE_MATRIX_TMDB_ID
+        )
+        self.assertEqual(the_matrix["release_year"], 1999)
 
     def test_games(self):
         """Test the search method for games.

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -242,7 +242,7 @@ CACHES = {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": REDIS_URL,
         "TIMEOUT": CACHE_TIMEOUT,
-        "VERSION": 18,
+        "VERSION": 19,
         "KEY_PREFIX": KEY_PREFIX,
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",

--- a/src/templates/app/components/media_card.html
+++ b/src/templates/app/components/media_card.html
@@ -103,6 +103,9 @@
     <a href="{{ item|media_url }}"
        class="text-sm font-semibold text-white hover:text-indigo-400 transition duration-300 line-clamp-1"
        title="{{ title }}">{{ title }}</a>
+    {% if item.release_year %}
+      <div class="text-xs text-gray-400 mt-1 line-clamp-1">{{ item.release_year }}</div>
+    {% endif %}
   </div>
 
   {% if item.media_type == MediaTypes.EPISODE.value %}

--- a/src/templates/app/components/media_card_list.html
+++ b/src/templates/app/components/media_card_list.html
@@ -21,6 +21,13 @@
           </h3>
 
           <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-400">
+            {% if item.release_year %}
+              <span class="flex items-center gap-1">
+                {% include "app/icons/calendar.svg" with classes="w-4 h-4" %}
+                {{ item.release_year }}
+              </span>
+            {% endif %}
+
             <span class="flex items-center gap-1">
               {% icon item.media_type is_active=False extra_classes="w-4 h-4" %}
               {{ item.media_type|media_type_readable }}


### PR DESCRIPTION
Reads release year from TMDB search items response and shows in the app under the title.

This solves as currently it was hard to work with search especially with multiple releases and remakes under the same title. Related to https://github.com/FuzzyGrim/Yamtrack/issues/725 https://github.com/FuzzyGrim/Yamtrack/issues/960

This applies only to TMDB search, so for tv shows and movies. Can be extended later to others depending on usefulness.

<br>

## UI changes for grid

**Before:**
<img width="1455" height="902" alt="Screenshot 2026-05-27 at 11 10 52 PM" src="https://github.com/user-attachments/assets/1ab547ef-c211-45e9-9443-b4110ecd40cc" />

**After:**
<img width="1459" height="904" alt="Screenshot 2026-05-27 at 11 11 06 PM" src="https://github.com/user-attachments/assets/3a43ef22-932e-4823-b196-48165ffa60d9" />

<br>

## UI changes for list

**Before:**
<img width="1459" height="905" alt="Screenshot 2026-05-27 at 11 13 58 PM" src="https://github.com/user-attachments/assets/86049832-357d-4bb5-82a3-675ed1c71c2c" />

**After:**
<img width="1460" height="904" alt="Screenshot 2026-05-27 at 11 14 15 PM" src="https://github.com/user-attachments/assets/0d46b961-7cee-428b-902e-05ba54e8bb16" />


