### PR TITLE
fix: episode watch modal prefill dates using local timezone

### DIFF
--- a/src/app/templatetags/app_tags.py
+++ b/src/app/templatetags/app_tags.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 from pathlib import Path
 
 from django import template
@@ -118,16 +117,6 @@ def datetime_format(datetime, user):
         formatted_time = formats.time_format(local_dt, user.time_format)
         return f"{formatted_date} {formatted_time}"
     return formatted_date
-
-
-@register.simple_tag
-def now_plus_minutes(minutes):
-    """Return a date/datetime-local value for now plus minutes."""
-    minutes = int(minutes)
-    local_dt = timezone.localtime(timezone.now() + timedelta(minutes=minutes))
-    if settings.TRACK_TIME:
-        return local_dt.strftime("%Y-%m-%dT%H:%M")
-    return local_dt.strftime("%Y-%m-%d")
 
 
 @register.filter

--- a/src/app/tests/test_templatetags.py
+++ b/src/app/tests/test_templatetags.py
@@ -181,44 +181,6 @@ class AppTagsTests(TestCase):
             # Check that it returns a non-empty string
             self.assertTrue(isinstance(result, str))
 
-    @override_settings(TRACK_TIME=True)
-    def test_now_plus_minutes_with_time(self):
-        """Test now plus minutes with TRACK_TIME enabled."""
-        with (
-            timezone.override("UTC"),
-            patch("django.utils.timezone.now") as mock_now,
-        ):
-            mock_now.return_value = timezone.datetime(
-                2025,
-                3,
-                29,
-                12,
-                0,
-                0,
-                tzinfo=timezone.get_current_timezone(),
-            )
-
-            self.assertEqual(app_tags.now_plus_minutes(90), "2025-03-29T13:30")
-
-    @override_settings(TRACK_TIME=False)
-    def test_now_plus_minutes_without_time(self):
-        """Test now plus minutes with TRACK_TIME disabled."""
-        with (
-            timezone.override("UTC"),
-            patch("django.utils.timezone.now") as mock_now,
-        ):
-            mock_now.return_value = timezone.datetime(
-                2025,
-                3,
-                29,
-                12,
-                0,
-                0,
-                tzinfo=timezone.get_current_timezone(),
-            )
-
-            self.assertEqual(app_tags.now_plus_minutes(90), "2025-03-29")
-
     @override_settings(TRACK_TIME=False)
     def test_natural_day(self):
         """Test the natural_day filter."""

--- a/src/templates/app/components/fill_track_episode.html
+++ b/src/templates/app/components/fill_track_episode.html
@@ -69,14 +69,11 @@
       {% endif %}
 
       {# Episode track form #}
-      {% if episode.runtime_minutes %}
-        {% now_plus_minutes episode.runtime_minutes as finish_datetime %}
-      {% endif %}
       {# djlint:off #}
       <form method="post"
             action="{% url 'episode_save' %}?next={{ request.path }}"
             x-data="{
-              inputDateTime: '{% if TRACK_TIME %}{% now "Y-m-d\TH:i" %}{% else %}{% now "Y-m-d" %}{% endif %}',
+              inputDateTime: new Date(Date.now() - new Date().getTimezoneOffset() * 60000).toISOString().slice(0, {% if TRACK_TIME %}16{% else %}10{% endif %}),
               inputType: '{% if TRACK_TIME %}datetime-local{% else %}date{% endif %}',
               dropdownOpen: false,
               pointerOnPickerIcon: false
@@ -134,14 +131,14 @@
 
               {# Option A - Current Time #}
               <button type="button"
-                      @click="inputDateTime = '{% if TRACK_TIME %}{% now "Y-m-d\TH:i" %}{% else %}{% now "Y-m-d" %}{% endif %}'; dropdownOpen = false"
+                      @click="inputDateTime = new Date(Date.now() - new Date().getTimezoneOffset() * 60000).toISOString().slice(0, {% if TRACK_TIME %}16{% else %}10{% endif %}); dropdownOpen = false"
                       class="w-full text-left px-4 py-3 text-sm text-gray-200 hover:bg-indigo-600 hover:text-white transition-colors cursor-pointer"
                       title="Fills in the current date and time">Fill in current time</button>
 
               {% if episode.runtime_minutes %}
                 {# Option B - Finish Time #}
                 <button type="button"
-                        @click="inputDateTime = '{{ finish_datetime|escapejs }}'; dropdownOpen = false"
+                        @click="inputDateTime = new Date(Date.now() + {{ episode.runtime_minutes }} * 60000 - new Date().getTimezoneOffset() * 60000).toISOString().slice(0, {% if TRACK_TIME %}16{% else %}10{% endif %}); dropdownOpen = false"
                         class="w-full text-left px-4 py-3 text-sm text-gray-200 hover:bg-indigo-600 hover:text-white transition-colors cursor-pointer"
                         title="Fills in the date and time the episode will be finished if started now">
                   Fill in end time
@@ -151,7 +148,7 @@
               {# Option C - Air Date #}
               {% if episode.air_date %}
                 <button type="button"
-                        @click="inputDateTime = '{% if TRACK_TIME %}{{ episode.air_date|escapejs }}T{% now "H:i" %}{% else %}{{ episode.air_date|escapejs }}{% endif %}'; dropdownOpen = false"
+                        @click="inputDateTime = {% if TRACK_TIME %}'{{ episode.air_date|escapejs }}T' + new Date(Date.now() - new Date().getTimezoneOffset() * 60000).toISOString().slice(11, 16){% else %}'{{ episode.air_date|escapejs }}'{% endif %}; dropdownOpen = false"
                         class="w-full text-left px-4 py-3 text-sm text-gray-200 hover:bg-indigo-600 hover:text-white transition-colors cursor-pointer"
                         title="Fills in the air date of the episode, if available">Fill in air date</button>
               {% endif %}


### PR DESCRIPTION
Episode watch modal used UTC and not local timezone like the modal for movies. I have also removed `now_plus_minutes()` as I assume that uses server timezone not device local one.

This carries the similar logic as done in `mediaStatusDateHandler.js getCurrentDateTime()`, which does use local timezone.

Fixes https://github.com/FuzzyGrim/Yamtrack/issues/1374

Also setting TIMEZONE via env variables does fix it but it worked inconsistently as movie input read timezone from the client while episode input did not. Please provide feedback if this should work differently.

<br>

**Before:**
<img width="500" alt="Screenshot 2026-05-28 at 12 29 59 AM" src="https://github.com/user-attachments/assets/aa5cab8c-2f01-42f9-a38f-ef080a8dd632" />
<img width="500" alt="Screenshot 2026-05-28 at 12 30 24 AM" src="https://github.com/user-attachments/assets/31af30f1-de85-4d4f-9a59-6a0777306d2f" />

<br>

**After:**
<img width="500" alt="Screenshot 2026-05-28 at 12 30 44 AM" src="https://github.com/user-attachments/assets/0444bf71-3fff-4882-b7dc-59b2e3438918" />
