### PR TITLE
fix: allow generic username to restore PWA shortcuts

### DIFF
--- a/src/app/helpers.py
+++ b/src/app/helpers.py
@@ -8,13 +8,14 @@ from django.contrib import messages
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
 from django.http import Http404, HttpResponse, HttpResponseRedirect
-from django.shortcuts import redirect
+from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import iri_to_uri
 from django.utils.http import url_has_allowed_host_and_scheme
 
 from app.models import BasicMedia, Item, MediaTypes, Status
+from users.models import User
 
 YEAR_ONLY_PARTS = 1
 YEAR_MONTH_PARTS = 2
@@ -37,6 +38,14 @@ def get_owned_media_or_404(request, media_type, instance_id, *, prefetch=False):
     except ObjectDoesNotExist as exc:
         msg = "Media not found"
         raise Http404(msg) from exc
+
+
+def get_user_or_404(request, username):
+    """Return user or raise 404."""
+    if request.user.is_authenticated and username == "~":
+        return request.user
+
+    return get_object_or_404(User, username=username)
 
 
 def get_configured_app_url():

--- a/src/app/helpers.py
+++ b/src/app/helpers.py
@@ -41,8 +41,14 @@ def get_owned_media_or_404(request, media_type, instance_id, *, prefetch=False):
 
 
 def get_user_or_404(request, username):
-    """Return user or raise 404."""
-    if request.user.is_authenticated and username == "~":
+    """Return user or raise 404.
+
+    Special username '~' returns logged user.
+    '~' redirects to login page if no user logged in.
+    """
+    if username == "~":
+        if not request.user.is_authenticated:
+            return redirect(f"/accounts/login/?next={request.path}")
         return request.user
 
     return get_object_or_404(User, username=username)

--- a/src/app/tests/test_helpers.py
+++ b/src/app/tests/test_helpers.py
@@ -2,7 +2,7 @@ import json
 from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
-from django.http import HttpRequest
+from django.http import Http404, HttpRequest
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
@@ -11,6 +11,7 @@ from app.helpers import (
     enrich_items_with_user_data,
     form_error_messages,
     get_configured_app_url,
+    get_user_or_404,
     minutes_to_hhmm,
     redirect_back,
 )
@@ -318,3 +319,43 @@ class EnrichItemsWithUserDataTest(TestCase):
             self.request, raw_items, "recommendations"
         )
         self.assertEqual(len(enriched_items), 2)
+
+
+class GetUserOr404Test(TestCase):
+    """Test the get_user_or_404 function."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.credentials = {"username": "test", "password": "testpass"}
+        self.request = MagicMock()
+
+    def test_username_tilde_authenticated(self):
+        """If username is '~' and user authenticated, return logged user."""
+        self.request.user = get_user_model().objects.create_user(**self.credentials)
+        result = get_user_or_404(self.request, "~")
+
+        self.assertEqual(result, self.request.user)
+
+    @patch("app.helpers.redirect")
+    def test_username_tilde_unauthenticated(self, mock_redirect):
+        """If username is '~' and user is not authenticated, redirects to login page."""
+        self.request.user = MagicMock(is_authenticated=False)
+        self.request.path = "/~/tv"
+        mock_redirect.return_value = "redirect_to_login"
+
+        result = get_user_or_404(self.request, "~")
+
+        mock_redirect.assert_called_once_with("/accounts/login/?next=/~/tv")
+        self.assertEqual(result, "redirect_to_login")
+
+    def test_existing_username(self):
+        """Return the user if it exists."""
+        self.request.user = get_user_model().objects.create_user(**self.credentials)
+        result = get_user_or_404(self.request, "test")
+
+        self.assertEqual(result, self.request.user)
+
+    def test_non_existent_username_raises_404(self):
+        """Raises Http404 if the user does not exists."""
+        with self.assertRaises(Http404):
+            get_user_or_404(self.request, "foo")

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -11,7 +11,7 @@ from django.core.paginator import Paginator
 from django.db import IntegrityError
 from django.db.models import Prefetch, prefetch_related_objects
 from django.http import Http404, HttpResponse, HttpResponseBadRequest, JsonResponse
-from django.shortcuts import get_object_or_404, redirect, render
+from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.http import require_GET, require_http_methods, require_POST
@@ -39,7 +39,6 @@ from users.models import (
     HomeSortChoices,
     MediaSortChoices,
     MediaStatusChoices,
-    User,
 )
 
 logger = logging.getLogger(__name__)
@@ -162,7 +161,7 @@ def progress_edit(request, media_type, instance_id):
 @require_GET
 def media_list(request, username, media_type):
     """Return the media list page."""
-    target_user = get_object_or_404(User, username=username)
+    target_user = helpers.get_user_or_404(request, username)
 
     # if user is looking at own page then update preferences
     if request.user == target_user:

--- a/src/static/favicon/site.webmanifest
+++ b/src/static/favicon/site.webmanifest
@@ -75,7 +75,7 @@
             "name": "TV Shows",
             "short_name": "TV",
             "description": "View your TV Shows",
-            "url": "/medialist/tv",
+            "url": "/~/tv",
             "icons": [
                 {
                     "src": "/static/img/shortcuts/tv.svg",
@@ -87,7 +87,7 @@
             "name": "Movies",
             "short_name": "Movies",
             "description": "View your Movies",
-            "url": "/medialist/movie",
+            "url": "/~/movie",
             "icons": [
                 {
                     "src": "/static/img/shortcuts/movies.svg",
@@ -99,7 +99,7 @@
             "name": "Anime",
             "short_name": "Anime",
             "description": "View your Anime",
-            "url": "/medialist/anime",
+            "url": "/~/anime",
             "icons": [
                 {
                     "src": "/static/img/shortcuts/anime.svg",
@@ -111,7 +111,7 @@
             "name": "Manga",
             "short_name": "Manga",
             "description": "View your Mangas",
-            "url": "/medialist/manga",
+            "url": "/~/manga",
             "icons": [
                 {
                     "src": "/static/img/shortcuts/manga.svg",
@@ -123,7 +123,7 @@
             "name": "Games",
             "short_name": "Games",
             "description": "View your Games",
-            "url": "/medialist/game",
+            "url": "/~/game",
             "icons": [
                 {
                     "src": "/static/img/shortcuts/games.svg",
@@ -135,7 +135,7 @@
             "name": "Books",
             "short_name": "Books",
             "description": "View your Books",
-            "url": "/medialist/book",
+            "url": "/~/book",
             "icons": [
                 {
                     "src": "/static/img/shortcuts/books.svg",
@@ -147,7 +147,7 @@
             "name": "Comics",
             "short_name": "Comics",
             "description": "View your Comics",
-            "url": "/medialist/comic",
+            "url": "/~/comic",
             "icons": [
                 {
                     "src": "/static/img/shortcuts/comics.svg",
@@ -159,7 +159,7 @@
             "name": "Boardgames",
             "short_name": "Boardgames",
             "description": "View your Boardgames",
-            "url": "/medialist/boardgame",
+            "url": "/~/boardgame",
             "icons": [
                 {
                     "src": "/static/img/shortcuts/boardgames.svg",


### PR DESCRIPTION
To fix #1460, I propose to allow access to the current user media lists using a wildcard username in URLs (`/~/*`).