### PR TITLE
add option to fill in no date in fill_track_episode

### DIFF
--- a/src/templates/app/components/fill_track_episode.html
+++ b/src/templates/app/components/fill_track_episode.html
@@ -155,6 +155,12 @@
                         class="w-full text-left px-4 py-3 text-sm text-gray-200 hover:bg-indigo-600 hover:text-white transition-colors cursor-pointer"
                         title="Fills in the air date of the episode, if available">Fill in air date</button>
               {% endif %}
+                 
+              {# Option D - No Date #}
+              <button type="button"
+                      @click="inputDateTime = ''; dropdownOpen = false"
+                      class="w-full text-left px-4 py-3 text-sm text-gray-200 hover:bg-indigo-600 hover:text-white transition-colors cursor-pointer"
+                      title="Fills in nothing as the date and time">Fill in no date</button>
             </div>
 
           </div>


### PR DESCRIPTION
This PR adds an explicit option to clear the date field in the fill_track_episode dialog.

Unfortunately, not all platforms support clearing the date input field. For example, on my pixel 8 using firefox, I can clear the input field, but it does not allow me to set it ("set" button does not work in picture below). I propose we add an explicit option so that the user can easily clear the field, to add an episode as watched without a date.

<img width="921" height="1009" alt="WhatsApp Image 2026-05-31 at 21 36 31" src="https://github.com/user-attachments/assets/b74719a8-4415-4a95-bacb-49bc8bc6e4bb" />

I have verified the change on my desktop (linux, firefox) and on my google pixel 8 (firefox). I have ran the test suite just to be sure, all tests pass.

