### PR TITLE
Fix #1503 - Correct the episode text after +/- buttons clicked.

### DIFF
--- a/src/app/views.py
+++ b/src/app/views.py
@@ -114,6 +114,11 @@ def progress_edit(request, media_type, instance_id):
         media.refresh_from_db()
         prefetch_related_objects([media], "episodes")
 
+    BasicMedia.objects.annotate_max_progress(             
+        [media],                                          
+        media_type,                                              
+    )
+
     context = {
         "media": media,
     }


### PR DESCRIPTION
Simple fix for a cosmetic issue. See #1503 for more detail.