### PR TITLE
Implement #470 - Kodi integration

### DIFF
--- a/src/integrations/tests/test_webhooks_kodi.py
+++ b/src/integrations/tests/test_webhooks_kodi.py
@@ -1,0 +1,694 @@
+import json
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from app.models import TV, Episode, Item, MediaTypes, Movie, Season, Status
+from integrations.webhooks.kodi import KodiWebhookProcessor
+
+
+class KodiWebhookTests(TestCase):
+    """Tests for Kodi webhook."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.client = Client()
+        self.credentials = {"username": "testuser", "token": "test-token"}
+        self.user = get_user_model().objects.create_superuser(**self.credentials)
+        self.url = reverse("kodi_webhook", kwargs={"token": "test-token"})
+
+    def test_invalid_token(self):
+        """Test webhook with invalid token returns 401."""
+        url = reverse("kodi_webhook", kwargs={"token": "invalid-token"})
+        response = self.client.post(url, data={}, content_type="application/json")
+        self.assertEqual(response.status_code, 401)
+
+    def test_tv_episode_start_event(self):
+        """Test webhook handles TV episode start playback event."""
+        payload = {
+            "event": "start",
+            "dbId": 11328,
+            "title": "YABA",
+            "mediaType": "episode",
+            "year": 2026,
+            "uniqueIds": {"imdb": "tt35947243", "tvdb": "10991548"},
+            "duration": 2172,
+            "progress": {"time": 0, "percent": 0.0},
+            "tvShowTitle": "Maximum Pleasure Guaranteed",
+            "season": 1,
+            "episode": 2,
+            "firstAired": "2026-05-20",
+            "tvShowUniqueIds": {"imdb": "tt35946742", "tvdb": "460793"},
+        }
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # Verify objects were created
+        tv_item = Item.objects.get(media_type=MediaTypes.TV.value, media_id="285404")
+        self.assertEqual(tv_item.title, "Maximum Pleasure Guaranteed")
+
+        tv = TV.objects.get(item=tv_item, user=self.user)
+        self.assertEqual(tv.status, Status.IN_PROGRESS.value)
+
+        season = Season.objects.get(
+            item__media_id="285404",
+            item__season_number=1,
+        )
+        self.assertEqual(season.status, Status.IN_PROGRESS.value)
+
+        episodes = Episode.objects.filter(
+            item__media_id="285404",
+            item__season_number=1,
+            item__episode_number=2,
+        )
+        self.assertFalse(episodes)
+
+    def test_tv_episode_stop_event_pre_threshold(self):
+        """Test webhook handles TV episode stop playback event before the threshold."""
+        payload = {
+            "event": "stop",
+            "dbId": 11328,
+            "title": "YABA",
+            "mediaType": "episode",
+            "year": 2026,
+            "uniqueIds": {"imdb": "tt35947243", "tvdb": "10991548"},
+            "duration": 2172,
+            "progress": {"time": 1123, "percent": 51.703499079},
+            "tvShowTitle": "Maximum Pleasure Guaranteed",
+            "season": 1,
+            "episode": 2,
+            "firstAired": "2026-05-20",
+            "tvShowUniqueIds": {"imdb": "tt35946742", "tvdb": "460793"},
+        }
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # Verify objects were created
+        tv_item = Item.objects.get(media_type=MediaTypes.TV.value, media_id="285404")
+        self.assertEqual(tv_item.title, "Maximum Pleasure Guaranteed")
+
+        tv = TV.objects.get(item=tv_item, user=self.user)
+        self.assertEqual(tv.status, Status.IN_PROGRESS.value)
+
+        season = Season.objects.get(
+            item__media_id="285404",
+            item__season_number=1,
+        )
+        self.assertEqual(season.status, Status.IN_PROGRESS.value)
+
+        episodes = Episode.objects.filter(
+            item__media_id="285404",
+            item__season_number=1,
+            item__episode_number=2,
+        )
+        self.assertFalse(episodes)
+
+    def test_tv_episode_stop_event_post_threshold(self):
+        """Test webhook handles TV episode stop playback event after the threshold."""
+        payload = {
+            "event": "stop",
+            "dbId": 11328,
+            "title": "YABA",
+            "mediaType": "episode",
+            "year": 2026,
+            "uniqueIds": {"imdb": "tt35947243", "tvdb": "10991548"},
+            "duration": 2172,
+            "progress": {"time": 1801, "percent": 82.91896869244935},
+            "tvShowTitle": "Maximum Pleasure Guaranteed",
+            "season": 1,
+            "episode": 2,
+            "firstAired": "2026-05-20",
+            "tvShowUniqueIds": {"imdb": "tt35946742", "tvdb": "460793"},
+        }
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # Verify objects were created
+        tv_item = Item.objects.get(media_type=MediaTypes.TV.value, media_id="285404")
+        self.assertEqual(tv_item.title, "Maximum Pleasure Guaranteed")
+
+        tv = TV.objects.get(item=tv_item, user=self.user)
+        self.assertEqual(tv.status, Status.IN_PROGRESS.value)
+
+        season = Season.objects.get(
+            item__media_id="285404",
+            item__season_number=1,
+        )
+        self.assertEqual(season.status, Status.IN_PROGRESS.value)
+
+        episodes = Episode.objects.filter(
+            item__media_id="285404",
+            item__season_number=1,
+            item__episode_number=2,
+        )
+        self.assertTrue(episodes)
+        self.assertEqual(episodes.count(), 1)
+        episode = episodes[0]
+        self.assertIsNotNone(episode.end_date)
+
+    def test_tv_episode_repeat_stop_events_post_threshold(self):
+        """Test webhook handles TV episode stop playback event after the threshold."""
+        payload = {
+            "event": "stop",
+            "dbId": 11328,
+            "title": "YABA",
+            "mediaType": "episode",
+            "year": 2026,
+            "uniqueIds": {"imdb": "tt35947243", "tvdb": "10991548"},
+            "duration": 2172,
+            "progress": {"time": 1801, "percent": 82.91896869244935},
+            "tvShowTitle": "Maximum Pleasure Guaranteed",
+            "season": 1,
+            "episode": 2,
+            "firstAired": "2026-05-20",
+            "tvShowUniqueIds": {"imdb": "tt35946742", "tvdb": "460793"},
+        }
+
+        # First watch
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # Second watch
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # Verify objects were created
+        tv_item = Item.objects.get(media_type=MediaTypes.TV.value, media_id="285404")
+        self.assertEqual(tv_item.title, "Maximum Pleasure Guaranteed")
+
+        tv = TV.objects.get(item=tv_item, user=self.user)
+        self.assertEqual(tv.status, Status.IN_PROGRESS.value)
+
+        season = Season.objects.get(
+            item__media_id="285404",
+            item__season_number=1,
+        )
+        self.assertEqual(season.status, Status.IN_PROGRESS.value)
+
+        episodes = Episode.objects.filter(
+            item__media_id="285404",
+            item__season_number=1,
+            item__episode_number=2,
+        )
+        self.assertTrue(episodes)
+        self.assertEqual(episodes.count(), 1)
+        episode = episodes[0]
+        self.assertIsNotNone(episode.end_date)
+
+        history = episode.history.all()
+        self.assertTrue(history)
+
+        self.assertEqual(history.count(), 1)
+        self.assertIsNotNone(history[0].end_date)
+
+    def test_tv_episode_end_event(self):
+        """Test webhook handles TV episode stop playback event after the threshold."""
+        payload = {
+            "event": "end",
+            "dbId": 11328,
+            "title": "YABA",
+            "mediaType": "episode",
+            "year": 2026,
+            "uniqueIds": {"imdb": "tt35947243", "tvdb": "10991548"},
+            "duration": 2172,
+            "progress": {"time": 2172, "percent": 100},
+            "tvShowTitle": "Maximum Pleasure Guaranteed",
+            "season": 1,
+            "episode": 2,
+            "firstAired": "2026-05-20",
+            "tvShowUniqueIds": {"imdb": "tt35946742", "tvdb": "460793"},
+        }
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # Verify objects were created
+        tv_item = Item.objects.get(media_type=MediaTypes.TV.value, media_id="285404")
+        self.assertEqual(tv_item.title, "Maximum Pleasure Guaranteed")
+
+        tv = TV.objects.get(item=tv_item, user=self.user)
+        self.assertEqual(tv.status, Status.IN_PROGRESS.value)
+
+        season = Season.objects.get(
+            item__media_id="285404",
+            item__season_number=1,
+        )
+        self.assertEqual(season.status, Status.IN_PROGRESS.value)
+
+        episodes = Episode.objects.filter(
+            item__media_id="285404",
+            item__season_number=1,
+            item__episode_number=2,
+        )
+        self.assertTrue(episodes)
+        self.assertEqual(episodes.count(), 1)
+        episode = episodes[0]
+        self.assertIsNotNone(episode.end_date)
+
+    def test_tv_episode_repeat_end_events(self):
+        """Test webhook handles TV episode stop playback event after the threshold."""
+        payload = {
+            "event": "end",
+            "dbId": 11328,
+            "title": "YABA",
+            "mediaType": "episode",
+            "year": 2026,
+            "uniqueIds": {"imdb": "tt35947243", "tvdb": "10991548"},
+            "duration": 2172,
+            "progress": {"time": 2172, "percent": 100},
+            "tvShowTitle": "Maximum Pleasure Guaranteed",
+            "season": 1,
+            "episode": 2,
+            "firstAired": "2026-05-20",
+            "tvShowUniqueIds": {"imdb": "tt35946742", "tvdb": "460793"},
+        }
+
+        # First watch
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # Second watch
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # Verify objects were created
+        tv_item = Item.objects.get(media_type=MediaTypes.TV.value, media_id="285404")
+        self.assertEqual(tv_item.title, "Maximum Pleasure Guaranteed")
+
+        tv = TV.objects.get(item=tv_item, user=self.user)
+        self.assertEqual(tv.status, Status.IN_PROGRESS.value)
+
+        season = Season.objects.get(
+            item__media_id="285404",
+            item__season_number=1,
+        )
+        self.assertEqual(season.status, Status.IN_PROGRESS.value)
+
+        episodes = Episode.objects.filter(
+            item__media_id="285404",
+            item__season_number=1,
+            item__episode_number=2,
+        )
+        self.assertTrue(episodes)
+        self.assertEqual(episodes.count(), 1)
+        episode = episodes[0]
+        self.assertIsNotNone(episode.end_date)
+
+        history = episode.history.all()
+        self.assertTrue(history)
+
+        self.assertEqual(history.count(), 1)
+        self.assertIsNotNone(history[0].end_date)
+
+    def test_movie_start_event(self):
+        """Test webhook handles movie start event."""
+        payload = {
+            "event": "start",
+            "dbId": 593,
+            "title": "The Machine",
+            "mediaType": "movie",
+            "year": 2023,
+            "uniqueIds": {"imdb": "tt11040844", "tmdb": "647250"},
+            "duration": 6744,
+            "progress": {"time": 0, "percent": 0.0},
+            "premiered": "2023-05-25",
+        }
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # Verify movie was created and marked as in progress
+        movie = Movie.objects.get(
+            item__media_id="647250",
+            user=self.user,
+        )
+        self.assertEqual(movie.status, Status.IN_PROGRESS.value)
+        self.assertEqual(movie.progress, 0)
+
+    def test_movie_stop_event_pre_threshold(self):
+        """Test webhook handles movie stop pre threshold."""
+        payload = {
+            "event": "stop",
+            "dbId": 593,
+            "title": "The Machine",
+            "mediaType": "movie",
+            "year": 2023,
+            "uniqueIds": {"imdb": "tt11040844", "tmdb": "647250"},
+            "duration": 6744,
+            "progress": {"time": 3123, "percent": 46.3078292},
+            "premiered": "2023-05-25",
+        }
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # Verify movie was created and marked as in progress
+        movie = Movie.objects.get(
+            item__media_id="647250",
+            user=self.user,
+        )
+        self.assertEqual(movie.status, Status.IN_PROGRESS.value)
+        self.assertEqual(movie.progress, 0)
+
+    def test_movie_stop_event_post_threshold(self):
+        """Test webhook handles movie stop post threshold."""
+        payload = {
+            "event": "stop",
+            "dbId": 593,
+            "title": "The Machine",
+            "mediaType": "movie",
+            "year": 2023,
+            "uniqueIds": {"imdb": "tt11040844", "tmdb": "647250"},
+            "duration": 6744,
+            "progress": {"time": 6123, "percent": 90.7918149},
+            "premiered": "2023-05-25",
+        }
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # Verify movie was created and marked as completed
+        movie = Movie.objects.get(
+            item__media_id="647250",
+            user=self.user,
+        )
+        self.assertEqual(movie.status, Status.COMPLETED.value)
+        self.assertEqual(movie.progress, 1)
+
+    def test_movie_repeat_stop_events_post_threshold(self):
+        """Test webhook handles multiple movie stop post threshold."""
+        payload = {
+            "event": "stop",
+            "dbId": 593,
+            "title": "The Machine",
+            "mediaType": "movie",
+            "year": 2023,
+            "uniqueIds": {"imdb": "tt11040844", "tmdb": "647250"},
+            "duration": 6744,
+            "progress": {"time": 6123, "percent": 90.7918149},
+            "premiered": "2023-05-25",
+        }
+
+        # First watch
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # Second watch
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # Verify movie was created and marked as completed
+        movie = Movie.objects.filter(item__media_id="647250")
+        self.assertEqual(movie.count(), 2)
+        self.assertEqual(movie[0].status, Status.COMPLETED.value)
+        self.assertEqual(movie[1].status, Status.COMPLETED.value)
+
+    def test_movie_end_event(self):
+        """Test webhook handles movie stop end threshold."""
+        payload = {
+            "event": "end",
+            "dbId": 593,
+            "title": "The Machine",
+            "mediaType": "movie",
+            "year": 2023,
+            "uniqueIds": {"imdb": "tt11040844", "tmdb": "647250"},
+            "duration": 6744,
+            "progress": {"time": 6744, "percent": 100.0},
+            "premiered": "2023-05-25",
+        }
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # Verify movie was created and marked as completed
+        movie = Movie.objects.get(
+            item__media_id="647250",
+            user=self.user,
+        )
+        self.assertEqual(movie.status, Status.COMPLETED.value)
+        self.assertEqual(movie.progress, 1)
+
+    def test_movie_repeat_end_events(self):
+        """Test webhook handles multiple movie end post threshold."""
+        payload = {
+            "event": "end",
+            "dbId": 593,
+            "title": "The Machine",
+            "mediaType": "movie",
+            "year": 2023,
+            "uniqueIds": {"imdb": "tt11040844", "tmdb": "647250"},
+            "duration": 6744,
+            "progress": {"time": 6744, "percent": 100.0},
+            "premiered": "2023-05-25",
+        }
+
+        # First watch
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # Second watch
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # Verify movie was created and marked as completed
+        movie = Movie.objects.filter(item__media_id="647250")
+        self.assertEqual(movie.count(), 2)
+        self.assertEqual(movie[0].status, Status.COMPLETED.value)
+        self.assertEqual(movie[1].status, Status.COMPLETED.value)
+
+    def test_ignored_event_types(self):
+        """Test webhook ignores irrelevant event types."""
+        payload = {
+            "event": "somethingelse",
+            "dbId": 593,
+            "title": "The Machine",
+            "mediaType": "movie",
+            "year": 2023,
+            "uniqueIds": {"imdb": "tt11040844", "tmdb": "647250"},
+            "duration": 6744,
+            "progress": {"time": 6738, "percent": 99.91103202846975},
+            "premiered": "2023-05-25",
+        }
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Movie.objects.count(), 0)
+
+    def test_ignored_media_types(self):
+        """Test webhook ignores irrelevant event types."""
+        payload = {
+            "event": "end",
+            "dbId": 593,
+            "title": "The Machine",
+            "mediaType": "somethingelse",
+            "year": 2023,
+            "uniqueIds": {"imdb": "tt11040844", "tmdb": "647250"},
+            "duration": 6744,
+            "progress": {"time": 6738, "percent": 99.91103202846975},
+            "premiered": "2023-05-25",
+        }
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Movie.objects.count(), 0)
+
+    def test_missing_tmdb_id(self):
+        """Test webhook handles missing TMDB ID gracefully."""
+        payload = {
+            "event": "end",
+            "dbId": 593,
+            "title": "The Machine",
+            "mediaType": "movie",
+            "year": 2023,
+            "uniqueIds": {},
+            "duration": 6744,
+            "progress": {"time": 6738, "percent": 99.91103202846975},
+            "premiered": "2023-05-25",
+        }
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Movie.objects.count(), 0)
+
+    def test_extract_external_ids(self):
+        """Test extracting external IDs from uniqueIds payload."""
+        payload = {
+            "event": "end",
+            "dbId": 593,
+            "title": "The Machine",
+            "mediaType": "movie",
+            "year": 2023,
+            "uniqueIds": {"imdb": "tt11040844", "tmdb": "647250"},
+            "duration": 6744,
+            "progress": {"time": 6738, "percent": 99.91103202846975},
+            "premiered": "2023-05-25",
+        }
+
+        expected = {
+            "tmdb_id": "647250",
+            "imdb_id": "tt11040844",
+            "tvdb_id": None,
+        }
+
+        result = KodiWebhookProcessor()._extract_external_ids(payload)
+        if result != expected:
+            msg = f"Expected {expected}, got {result}"
+            raise AssertionError(msg)
+
+    def test_extract_external_ids_empty(self):
+        """Test handling empty uniqueIds payload."""
+        payload = {
+            "event": "end",
+            "dbId": 593,
+            "title": "The Machine",
+            "mediaType": "movie",
+            "year": 2023,
+            "uniqueIds": {},
+            "duration": 6744,
+            "progress": {"time": 6738, "percent": 99.91103202846975},
+            "premiered": "2023-05-25",
+        }
+
+        expected = {
+            "tmdb_id": None,
+            "imdb_id": None,
+            "tvdb_id": None,
+        }
+
+        result = KodiWebhookProcessor()._extract_external_ids(payload)
+        if result != expected:
+            msg = f"Expected {expected}, got {result}"
+            raise AssertionError(msg)
+
+    def test_extract_external_ids_missing(self):
+        """Test handling missing uniqueIds."""
+        payload = {
+            "event": "end",
+            "dbId": 593,
+            "title": "The Machine",
+            "mediaType": "movie",
+            "year": 2023,
+            "duration": 6744,
+            "progress": {"time": 6738, "percent": 99.91103202846975},
+            "premiered": "2023-05-25",
+        }
+
+        expected = {
+            "tmdb_id": None,
+            "imdb_id": None,
+            "tvdb_id": None,
+        }
+
+        result = KodiWebhookProcessor()._extract_external_ids(payload)
+        if result != expected:
+            msg = f"Expected {expected}, got {result}"
+            raise AssertionError(msg)
+
+    def test_get_episode_number(self):
+        """Test extracting episode number from Kodi payload."""
+        payload = {
+            "episode": 7,
+        }
+
+        result = KodiWebhookProcessor()._get_episode_number(payload)
+
+        self.assertEqual(result, 7)

--- a/src/integrations/urls.py
+++ b/src/integrations/urls.py
@@ -50,4 +50,9 @@ urlpatterns = [
         views.emby_webhook,
         name="emby_webhook",
     ),
+    path(
+        "webhook/kodi/<str:token>",
+        views.kodi_webhook,
+        name="kodi_webhook",
+    ),
 ]

--- a/src/integrations/views.py
+++ b/src/integrations/views.py
@@ -20,7 +20,7 @@ import users
 from app import helpers as app_helpers
 from integrations import exports, tasks
 from integrations.imports import anilist, helpers, simkl, trakt
-from integrations.webhooks import emby, jellyfin, plex
+from integrations.webhooks import emby, jellyfin, kodi, plex
 
 logger = logging.getLogger(__name__)
 
@@ -563,5 +563,36 @@ def emby_webhook(request, token):
 
     payload = json.loads(data)
     processor = emby.EmbyWebhookProcessor()
+    processor.process_payload(payload, user)
+    return HttpResponse(status=200)
+
+
+@login_not_required
+@csrf_exempt
+@require_POST
+def kodi_webhook(request, token):
+    """Handle Kodi webhook notifications for media playback."""
+    try:
+        user = users.models.User.objects.get(token=token)
+    except ObjectDoesNotExist:
+        logger.warning(
+            "Could not process Kodi webhook: Invalid token: %s",
+            token,
+        )
+        return HttpResponse(status=401)
+
+    # Attach User instance so history_user_id is populated
+    request.user = user
+
+    # The payload is sent in JSON format as the body of a
+    # HTTP POST request.
+
+    data = request.body
+    if not data:
+        logger.warning("Missing payload in Kodi webhook request")
+        return HttpResponse("Missing payload", status=400)
+
+    payload = json.loads(data)
+    processor = kodi.KodiWebhookProcessor()
     processor.process_payload(payload, user)
     return HttpResponse(status=200)

--- a/src/integrations/webhooks/kodi.py
+++ b/src/integrations/webhooks/kodi.py
@@ -1,0 +1,93 @@
+import json
+import logging
+from enum import StrEnum
+
+from app.models import MediaTypes
+
+from .base import BaseWebhookProcessor
+
+logger = logging.getLogger(__name__)
+
+PERCENT_COMPLETE_THRESHOLD = 80
+
+
+class KodiEvent(StrEnum):
+    """Kodi webhook event names."""
+
+    PLAYBACK_START = "start"
+    PLAYBACK_STOP = "stop"
+    PLAYBACK_END = "end"
+
+
+class KodiWebhookProcessor(BaseWebhookProcessor):
+    """Processor for Kodi webhook events."""
+
+    def process_payload(self, payload, user):
+        """Process the incoming Kodi webhook payload."""
+        logger.debug(
+            "Processing Kodi webhook payload: %s",
+            json.dumps(payload, indent=2),
+        )
+
+        event_type = payload.get("event")
+        if not self._is_supported_event(event_type):
+            logger.debug("Ignoring Kodi webhook event type: %s", event_type)
+            return
+
+        ids = self._extract_external_ids(payload)
+        logger.info("Extracted IDs from payload: %s", ids)
+
+        if not any(ids.values()):
+            logger.warning("Ignoring Kodi webhook call because no ID was found.")
+            return
+
+        self._process_media(payload, user, ids)
+
+    def _is_supported_event(self, event_type):
+        return event_type in {
+            KodiEvent.PLAYBACK_START,
+            KodiEvent.PLAYBACK_STOP,
+            KodiEvent.PLAYBACK_END,
+        }
+
+    def _is_played(self, payload):
+        if payload.get("event") == KodiEvent.PLAYBACK_END:
+            return True
+
+        if payload.get("event") == KodiEvent.PLAYBACK_STOP:
+            percent = payload.get("progress", 0).get("percent", 0)
+            if percent and percent > PERCENT_COMPLETE_THRESHOLD:
+                return True
+        return False
+
+    def _get_media_type(self, payload):
+        return self.MEDIA_TYPE_MAPPING.get(payload.get("mediaType").capitalize())
+
+    def _get_media_title(self, payload):
+        """Get media title from payload."""
+        title = None
+
+        if self._get_media_type(payload) == MediaTypes.TV.value:
+            series_name = payload.get("tvShowTitle")
+            season_number = payload.get("season")
+            episode_number = payload.get("episode")
+            title = f"{series_name} S{season_number:02d}E{episode_number:02d}"
+
+        elif self._get_media_type(payload) == MediaTypes.MOVIE.value:
+            movie_name = payload.get("title")
+            year = payload.get("year")
+
+            title = f"{movie_name} ({year})" if movie_name and year else movie_name
+
+        return title
+
+    def _get_episode_number(self, payload):
+        return payload.get("episode")
+
+    def _extract_external_ids(self, payload):
+        provider_ids = payload.get("uniqueIds", {})
+        return {
+            "tmdb_id": provider_ids.get("tmdb"),
+            "imdb_id": provider_ids.get("imdb"),
+            "tvdb_id": provider_ids.get("tvdb"),
+        }

--- a/src/templates/users/integrations.html
+++ b/src/templates/users/integrations.html
@@ -13,6 +13,8 @@
   {% absolute_app_url plex_webhook_path as plex_webhook_url %}
   {% url 'emby_webhook' request.user.token as emby_webhook_path %}
   {% absolute_app_url emby_webhook_path as emby_webhook_url %}
+  {% url 'kodi_webhook' request.user.token as kodi_webhook_path %}
+  {% absolute_app_url kodi_webhook_path as kodi_webhook_url %}
   <div class="space-y-6">
     <div class="bg-[#2a2f35] rounded-lg p-6">
       <div class="flex items-center mb-4">
@@ -87,6 +89,15 @@
                   :aria-selected="activeIntegration === 'emby'">
             {% include "app/icons/server.svg" with classes="w-4 h-4 mr-2" %}
             Emby
+          </button>
+          <button type="button"
+                  class="flex items-center px-4 py-2 rounded-md transition-colors text-sm cursor-pointer"
+                  :class="activeIntegration === 'kodi' ? 'bg-indigo-600 text-white' : 'bg-[#39404b] text-gray-300 hover:bg-[#454d59]'"
+                  @click="activeIntegration = 'kodi'"
+                  role="tab"
+                  :aria-selected="activeIntegration === 'kodi'">
+            {% include "app/icons/server.svg" with classes="w-4 h-4 mr-2" %}
+            Kodi
           </button>
         </div>
         <div x-cloak x-show="activeIntegration === 'jellyfin'" role="tabpanel">
@@ -348,6 +359,87 @@
                       <li>"Limit library events to" and "Limit devices events to" are optional</li>
                     </ul>
                   </li>
+                </ol>
+              </div>
+            </div>
+          </div>
+          <div x-cloak x-show="activeIntegration === 'kodi'" role="tabpanel">
+            <div class="bg-[#39404b] p-5 rounded-lg mb-6">
+              <div class="flex items-center mb-3">
+                {% include "app/icons/server.svg" with classes="w-5 h-5 text-indigo-400 mr-2" %}
+                <h3 class="text-base font-medium">Kodi</h3>
+              </div>
+              <p class="text-gray-400 mb-4 text-sm">Connect Kodi to automatically track your watching progress.</p>
+              <div class="bg-[#262a2f] p-4 rounded-md">
+                <h4 class="text-sm font-medium mb-3">Get the Kodi Add-on</h4>
+                <ol class="list-decimal list-inside space-y-2 text-sm text-gray-300">
+                  <li>
+                    Download the
+                    <a href="https://github.com/Programie/KodiAddon-HttpScrobbler/archive/refs/heads/main.zip"
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       class="text-indigo-400 hover:underline">KodiAddon-HttpScrobbler</a>.
+                  </li>
+                  <li>
+                    Follow the
+                    <a href="https://github.com/Programie/KodiAddon-HttpScrobbler"
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       class="text-indigo-400 hover:underline">Installation instructions</a>
+                    in the README.
+                  </li>
+                </ol>
+                <br />
+                <h4 class="text-sm font-medium mb-3">Setup Instructions</h4>
+                <p class="text-gray-400 mb-4 text-sm">
+                  Entering big long API keys in Kodi is painful, and copy and paste doesn't work, but there is a trick to doing it easily.
+                </p>
+                <ol class="list-decimal list-inside space-y-2 text-sm text-gray-300">
+                  <li>In Kodi, go to Settings > Services > Control</li>
+                  <li>Set 'Allow remote control via HTTP' - you will have to set a password first if 'Require authentication' is on.</li>
+                  <li>
+                    Open the Kodi web interface in a browser. If you are using the defaults it will be something like:
+                    {# djlint:off #}
+                    <a href="http://localhost:1234/"
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       class="text-indigo-400 hover:underline">http://localhost:1234/</a>
+                    {# djlint:on #}
+                  </li>
+                  <li>In Kodi, go to Settings > Add-ons > My add-ons > Services > HTTP Scrobbler > Configure</li>
+                  <li>Click or activate the URL field, so it is the only field on screen with the on-screen keyboard.</li>
+                  <li>In the Kodi web interface click the triple-dot menu in the lower left, and select 'Send text to Kodi'.</li>
+                  <li>
+                    Now paste the following URL into the Kodi web browser, and it will paste the text into the Kodi application.
+                    <ul class="list-disc list-inside ml-6 mt-2 space-y-2 text-gray-400">
+                      {# djlint:off #}
+                      <li>
+                        <div class="inline-flex items-center gap-2 w-[calc(100%-30px)]">URL:
+                          <input readonly
+                                 id="kodi-webhook-url"
+                                 class="w-full bg-[#262a2f] rounded-md text-gray-400 text-sm border-0 focus:ring-0 outline-none font-mono"
+                                 type="text"
+                                 value="{{ kodi_webhook_url }}">
+                          <span class="flex items-center cursor-pointer group"
+                                title="Copy"
+                                data-copy-target="#kodi-webhook-url">
+                            {% include "app/icons/copy.svg" with classes="w-5 h-5 text-gray-400 group-hover:text-indigo-400 transition-colors" %}
+                          </span>
+                        </div>
+                      </li>
+                      {# djlint:on #}
+                    </ul>
+                  </li>
+                  <li>
+                    Finally, back in the Kodi application, you can set the following:
+                    <ul class="list-disc list-inside ml-6 mt-2 space-y-2 text-gray-400">
+                      <li>Username and Password left blank.</li>
+                      <li>Limit Scrobbling Events to: Start, Stopped and Finished (others should be off as they are not used.)</li>
+                      <li>Ignore Update Interval</li>
+                      <li>Keep both types on</li>
+                    </ul>
+                  </li>
+                  <li>Remember to go back and disable the Kodi web interface if you do not intend to use it.</li>
                 </ol>
               </div>
             </div>


### PR DESCRIPTION
Implement #470 - I have created an integration for Kodi making use of the Kodi add-on HTTP Scrobbler. If they do not already exist, items are added to Yamtrack when played. An item is considered "watched" at 80% complete or when the video hits the end of the file.