### PR TITLE
fix: skip entries where TMDB returns a provider API error during Trakt import

### DIFF
--- a/src/integrations/imports/trakt.py
+++ b/src/integrations/imports/trakt.py
@@ -311,6 +311,12 @@ class TraktImporter:
                         watched_at,
                     )
                     self.process_watched_episode(entry)
+            except services.ProviderAPIError as e:
+                entry_data = entry.get("movie", entry.get("show", {}))
+                title = entry_data.get("title", "unknown")
+                msg = f"{title}: Skipped — provider API error ({e})"
+                logger.warning(msg)
+                self.warnings.append(msg)
             except Exception as e:
                 msg = f"Error processing history entry: {entry}"
                 raise MediaImportUnexpectedError(msg) from e

--- a/src/integrations/imports/trakt.py
+++ b/src/integrations/imports/trakt.py
@@ -594,6 +594,12 @@ class TraktImporter:
                     "watchlist",
                     {"status": Status.PLANNING.value},
                 )
+            except services.ProviderAPIError as e:
+                entry_data = entry.get("movie", entry.get("show", {}))
+                title = entry_data.get("title", "unknown")
+                msg = f"{title}: Skipped — provider API error ({e})"
+                logger.warning(msg)
+                self.warnings.append(msg)
             except Exception as e:
                 msg = f"Error processing watchlist entry: {entry}"
                 raise MediaImportUnexpectedError(msg) from e
@@ -611,6 +617,12 @@ class TraktImporter:
                     "rating",
                     {"score": entry["rating"]},
                 )
+            except services.ProviderAPIError as e:
+                entry_data = entry.get("movie", entry.get("show", {}))
+                title = entry_data.get("title", "unknown")
+                msg = f"{title}: Skipped — provider API error ({e})"
+                logger.warning(msg)
+                self.warnings.append(msg)
             except Exception as e:
                 msg = f"Error processing rating entry: {entry}"
                 raise MediaImportUnexpectedError(msg) from e
@@ -628,6 +640,12 @@ class TraktImporter:
                     "comment",
                     {"notes": entry["comment"]["comment"]},
                 )
+            except services.ProviderAPIError as e:
+                entry_data = entry.get("movie", entry.get("show", {}))
+                title = entry_data.get("title", "unknown")
+                msg = f"{title}: Skipped — provider API error ({e})"
+                logger.warning(msg)
+                self.warnings.append(msg)
             except Exception as e:
                 msg = f"Error processing comment entry: {entry}"
                 raise MediaImportUnexpectedError(msg) from e


### PR DESCRIPTION
Fixes #1529

## What

Four import loops in `trakt.py` — `process_history()`, `process_watchlist()`, `process_ratings()`, and `process_comments()` — all had the same pattern: a single `except Exception` block that re-raised any error as `MediaImportUnexpectedError`, aborting the entire import job.

This change adds a `except services.ProviderAPIError` branch above each generic handler. When TMDB (or another provider) returns a 5xx/4xx error for a specific entry, that entry is skipped, a warning is logged, and the title is appended to `self.warnings` so the user sees what was dropped in the import results. Genuine unexpected errors still surface via the existing `except Exception` path.

## Why

TMDB occasionally returns HTTP 500 or 502 for specific movie IDs (confirmed with IDs 16873 "Battle for Terra" and 896536 "The Legend of Ochi"). These are provider-side issues unrelated to the rest of the user's history or watchlist. Aborting the whole import for one bad entry means users can never complete an import if any entry hits a dead TMDB ID.

## Test plan

- [ ] Trakt import with all healthy TMDB IDs completes as before
- [ ] Trakt import containing a movie whose TMDB ID returns 500/502 completes successfully; the movie title appears in the import warnings
- [ ] Same for watchlist, ratings, and comments imports