### PR TITLE
refactor: move home page helpers out of views.py

### DIFF
--- a/src/app/home.py
+++ b/src/app/home.py
@@ -1,0 +1,126 @@
+from django.utils.text import slugify
+
+from app.models import BasicMedia, Status
+
+
+def build_home_section(key, media_types):
+    """Build home section payload."""
+    return {
+        "key": key,
+        "id": slugify(key),
+        "media_types": media_types,
+        "count": sum(media_list["total"] for media_list in media_types.values()),
+    }
+
+
+def is_active_in_progress_media(media):
+    """Return True when media still has released backlog."""
+    if not _is_incoming_media(media):
+        return True
+
+    return media.max_progress is not None and media.progress < media.max_progress
+
+
+def get_home_section_media_types(
+    request,
+    sort_by,
+    section_key,
+    items_limit,
+    *,
+    hide_unreleased=False,
+):
+    """Return media types for a home section."""
+    media_types = BasicMedia.objects.get_home_status(
+        user=request.user,
+        status=section_key,
+        sort_by=sort_by,
+        items_limit=None if hide_unreleased else items_limit,
+    )
+
+    if not hide_unreleased:
+        return media_types
+
+    return _paginate_home_media_types(
+        _filter_home_media_types(
+            media_types,
+            lambda media: _is_released_home_media(media, section_key),
+        ),
+        items_limit,
+    )
+
+
+def get_home_load_more_media_types(
+    request,
+    sort_by,
+    section_key,
+    items_limit,
+    media_type_to_load,
+    *,
+    hide_unreleased=False,
+):
+    """Return load-more payload for a specific home section/media type."""
+    media_types = BasicMedia.objects.get_home_status(
+        user=request.user,
+        status=section_key,
+        sort_by=sort_by,
+        items_limit=None if hide_unreleased else items_limit,
+        specific_media_type=media_type_to_load,
+    )
+
+    if not hide_unreleased:
+        return media_types
+
+    return _paginate_home_media_types(
+        _filter_home_media_types(
+            media_types,
+            lambda media: _is_released_home_media(media, section_key),
+        ),
+        items_limit,
+        page_start=items_limit,
+    )
+
+
+def get_home_section_keys():
+    """Return ordered home section keys for current user."""
+    return [Status.IN_PROGRESS.value, Status.PLANNING.value]
+
+
+def _filter_home_media_types(media_types, predicate):
+    """Filter home media entries by predicate."""
+    filtered_media_types = {}
+    for media_type, media_list in media_types.items():
+        filtered_items = [media for media in media_list["items"] if predicate(media)]
+        if filtered_items:
+            filtered_media_types[media_type] = {
+                "items": filtered_items,
+                "total": len(filtered_items),
+            }
+    return filtered_media_types
+
+
+def _paginate_home_media_types(media_types, items_limit, page_start=0):
+    """Paginate already-grouped home media entries."""
+    paginated_media_types = {}
+    for media_type, media_list in media_types.items():
+        page_end = None if items_limit is None else page_start + items_limit
+        items = media_list["items"][page_start:page_end]
+
+        if items or (page_start > 0 and media_list["total"]):
+            paginated_media_types[media_type] = {
+                "items": items,
+                "total": media_list["total"],
+            }
+    return paginated_media_types
+
+
+def _is_incoming_media(media):
+    """Return True when media has a real upcoming release."""
+    return bool(media.next_event and not media.next_event.is_max_datetime)
+
+
+def _is_released_home_media(media, section_key):
+    """Return True when media should remain after hiding unreleased entries."""
+    if section_key == Status.IN_PROGRESS.value:
+        return is_active_in_progress_media(media)
+
+    return not _is_incoming_media(media)

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -14,11 +14,11 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.dateparse import parse_date
-from django.utils.text import slugify
 from django.utils.timezone import datetime
 from django.views.decorators.http import require_GET, require_http_methods, require_POST
 
 from app import config, helpers, history_processor
+from app import home as home_helpers
 from app import statistics as stats
 from app.forms import EpisodeForm, ManualItemForm, get_form_class
 from app.models import (
@@ -46,129 +46,6 @@ from users.models import (
 logger = logging.getLogger(__name__)
 
 
-def _build_home_section(key, media_types):
-    """Build home section payload."""
-    return {
-        "key": key,
-        "id": slugify(key),
-        "media_types": media_types,
-        "count": sum(media_list["total"] for media_list in media_types.values()),
-    }
-
-
-def _filter_home_media_types(media_types, predicate):
-    """Filter home media entries by predicate."""
-    filtered_media_types = {}
-    for media_type, media_list in media_types.items():
-        filtered_items = [media for media in media_list["items"] if predicate(media)]
-        if filtered_items:
-            filtered_media_types[media_type] = {
-                "items": filtered_items,
-                "total": len(filtered_items),
-            }
-    return filtered_media_types
-
-
-def _paginate_home_media_types(media_types, items_limit, page_start=0):
-    """Paginate already-grouped home media entries."""
-    paginated_media_types = {}
-    for media_type, media_list in media_types.items():
-        page_end = None if items_limit is None else page_start + items_limit
-        items = media_list["items"][page_start:page_end]
-
-        if items or (page_start > 0 and media_list["total"]):
-            paginated_media_types[media_type] = {
-                "items": items,
-                "total": media_list["total"],
-            }
-    return paginated_media_types
-
-
-def _is_incoming_media(media):
-    """Return True when media has a real upcoming release."""
-    return bool(media.next_event and not media.next_event.is_max_datetime)
-
-
-def _is_active_in_progress_media(media):
-    """Return True when media still has released backlog."""
-    if not _is_incoming_media(media):
-        return True
-
-    return media.max_progress is not None and media.progress < media.max_progress
-
-
-def _is_released_home_media(media, section_key):
-    """Return True when media should remain after hiding unreleased entries."""
-    if section_key == Status.IN_PROGRESS.value:
-        return _is_active_in_progress_media(media)
-
-    return not _is_incoming_media(media)
-
-
-def _get_home_section_media_types(
-    request,
-    sort_by,
-    section_key,
-    items_limit,
-    *,
-    hide_unreleased=False,
-):
-    """Return media types for a home section."""
-    media_types = BasicMedia.objects.get_home_status(
-        user=request.user,
-        status=section_key,
-        sort_by=sort_by,
-        items_limit=None if hide_unreleased else items_limit,
-    )
-
-    if not hide_unreleased:
-        return media_types
-
-    return _paginate_home_media_types(
-        _filter_home_media_types(
-            media_types,
-            lambda media: _is_released_home_media(media, section_key),
-        ),
-        items_limit,
-    )
-
-
-def _get_home_load_more_media_types(
-    request,
-    sort_by,
-    section_key,
-    items_limit,
-    media_type_to_load,
-    *,
-    hide_unreleased=False,
-):
-    """Return load-more payload for a specific home section/media type."""
-    media_types = BasicMedia.objects.get_home_status(
-        user=request.user,
-        status=section_key,
-        sort_by=sort_by,
-        items_limit=None if hide_unreleased else items_limit,
-        specific_media_type=media_type_to_load,
-    )
-
-    if not hide_unreleased:
-        return media_types
-
-    return _paginate_home_media_types(
-        _filter_home_media_types(
-            media_types,
-            lambda media: _is_released_home_media(media, section_key),
-        ),
-        items_limit,
-        page_start=items_limit,
-    )
-
-
-def _get_home_section_keys():
-    """Return ordered home section keys for current user."""
-    return [Status.IN_PROGRESS.value, Status.PLANNING.value]
-
-
 @require_GET
 def home(request):
     """Home page with media items in progress and planning."""
@@ -187,7 +64,7 @@ def home(request):
 
     # If this is an HTMX request to load more items for a specific media type
     if request.headers.get("HX-Request") and media_type_to_load:
-        list_by_type = _get_home_load_more_media_types(
+        list_by_type = home_helpers.get_home_load_more_media_types(
             request,
             sort_by,
             section_to_load,
@@ -209,9 +86,9 @@ def home(request):
         )
 
     home_sections = [
-        _build_home_section(
+        home_helpers.build_home_section(
             section_key,
-            _get_home_section_media_types(
+            home_helpers.get_home_section_media_types(
                 request,
                 sort_by,
                 section_key,
@@ -219,7 +96,7 @@ def home(request):
                 hide_unreleased=hide_unreleased,
             ),
         )
-        for section_key in _get_home_section_keys()
+        for section_key in home_helpers.get_home_section_keys()
     ]
 
     context = {
@@ -269,7 +146,7 @@ def progress_edit(request, media_type, instance_id):
             BasicMedia.objects.annotate_max_progress([media], media_type)
         BasicMedia.objects._annotate_next_event([media])
 
-        if not _is_active_in_progress_media(media):
+        if not home_helpers.is_active_in_progress_media(media):
             response = HttpResponse()
             response["HX-Retarget"] = f"#home-media-{media.item.media_type}-{media.id}"
             response["HX-Reswap"] = "delete"


### PR DESCRIPTION
## Summary
- Move the non-view helper functions used by `home()` and `progress_edit()` (`_build_home_section`, `_get_home_section_media_types`, `_get_home_load_more_media_types`, `_get_home_section_keys`, `_is_active_in_progress_media`, and their private supporting functions) out of `src/app/views.py` into a new `src/app/home.py` module.
- Mirrors the existing pattern of `history_processor.py` and `statistics.py`: `views.py` now only contains view functions, business logic lives in its own module.
- No behavior change — call sites updated to use `home_helpers.*`.

## Test plan
- [x] `uv run ruff check src/app/views.py src/app/home.py`
- [x] `uv run python manage.py test app.tests.views.test_home`
- [x] `uv run python manage.py test app` (313 tests, all passing)