### PR TITLE
fix: Speed up health checks and media navigation

### DIFF
--- a/docs/env-variables.md
+++ b/docs/env-variables.md
@@ -45,7 +45,7 @@ See [media-imports](media-imports.md).
 | `PUID`                          | User ID for the app. Default to `1000`.                                                                                                                               |
 | `PGID`                          | Group ID for the app. Default to `1000`.                                                                                                                              |
 | `TZ`                            | Timezone (e.g., `Europe/Berlin`). Default to `UTC`.                                                                                                                   |
-| `WEB_CONCURRENCY`               | Number of web server processes. Default to `1`.                                                                                                                       |
+| `WEB_CONCURRENCY`               | Number of web server processes. Default to `2`.                                                                                                                       |
 | `SOCIAL_PROVIDERS`              | Comma-separated list of social authentication providers to enable (e.g., `allauth.socialaccount.providers.openid_connect,allauth.socialaccount.providers.github`).    |
 | `SOCIALACCOUNT_PROVIDERS`       | JSON configuration for social providers. See the [Docs](social-auth.md) for an OIDC configuration example.                                                            |
 | `ACCOUNT_DEFAULT_HTTP_PROTOCOL` | Protocol for social providers. If your `redirect_uri` in OIDC config is `https`, set this to `https`. Default is determined based on your `CSRF` settings.            |
@@ -54,11 +54,18 @@ See [media-imports](media-imports.md).
 | `REDIRECT_LOGIN_TO_SSO`         | Default to `False`. Set to `True` to automatically redirect (using JavaScript) to the SSO provider when there's only one available. Useful for single sign-on setups. |
 | `YAMTRACK_AUTO_LOGIN_USERNAME`  | Default to `None`, which disables this feature. Specify a username to automatically login with the selected user. The user needs to be existing and active.           |
 
-## Celery Health Check
+## Health Checks
+
+The default `/health/` endpoint is a lightweight unauthenticated check for the
+database, Django cache, and Redis. It does not ping Celery and is intended for
+container and reverse proxy health probes.
+
+Use `/health/full/` for the deeper `django-health-check` endpoint. It includes
+the database, cache, Redis, and Celery ping checks.
 
 | Name                              | Notes                                                                                                           |
 | --------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `HEALTHCHECK_CELERY_PING_TIMEOUT` | Default to `1`. Increases the timeout for the health check ping to Celery. This is useful for slow connections. |
+| `HEALTHCHECK_CELERY_PING_TIMEOUT` | Default to `1`. Increases the timeout for the `/health/full/` Celery ping check. This is useful for slow connections. |
 
 ## PostgreSQL Environment Variables (YamTrack Container)
 

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -223,7 +223,18 @@ class MediaManager(models.Manager):
         """Return list of historical model names."""
         return [f"historical{media_type}" for media_type in MediaTypes.values]
 
-    def get_media_list(self, user, media_type, status_filter, sort_filter, search=None):
+    def get_media_list(
+        self,
+        user,
+        media_type,
+        status_filter,
+        sort_filter,
+        search=None,
+        *,
+        prefetch_events=False,
+        event_queryset=None,
+        prefetch_related=True,
+    ):
         """Get media list based on filters, sorting and search."""
         model = apps.get_model(app_label="app", model_name=media_type)
         queryset = model.objects.filter(user=user.id)
@@ -247,16 +258,33 @@ class MediaManager(models.Manager):
         ).filter(row_number=1)
 
         queryset = queryset.select_related("item")
-        queryset = self._apply_prefetch_related(queryset, media_type)
+        if prefetch_related:
+            queryset = self._apply_prefetch_related(
+                queryset,
+                media_type,
+                prefetch_events=prefetch_events,
+                event_queryset=event_queryset,
+                prefetch_tv_children=False,
+            )
 
         if sort_filter:
             return self._sort_media_list(queryset, sort_filter, media_type)
         return queryset
 
-    def _apply_prefetch_related(self, queryset, media_type):
+    def _apply_prefetch_related(
+        self,
+        queryset,
+        media_type,
+        *,
+        prefetch_events=False,
+        event_queryset=None,
+        prefetch_tv_children=True,
+    ):
         """Apply appropriate prefetch_related based on media type."""
         # Apply media-specific prefetches
         if media_type == MediaTypes.TV.value:
+            if not prefetch_tv_children:
+                return queryset
             return queryset.prefetch_related(
                 Prefetch(
                     "seasons",
@@ -268,13 +296,15 @@ class MediaManager(models.Manager):
                 ),
             )
 
-        base_queryset = queryset.prefetch_related(
-            Prefetch(
-                "item__event_set",
-                queryset=events.models.Event.objects.all(),
-                to_attr="prefetched_events",
-            ),
-        )
+        base_queryset = queryset
+        if prefetch_events:
+            base_queryset = base_queryset.prefetch_related(
+                Prefetch(
+                    "item__event_set",
+                    queryset=event_queryset or events.models.Event.objects.all(),
+                    to_attr="prefetched_events",
+                ),
+            )
 
         if media_type == MediaTypes.SEASON.value:
             return base_queryset.prefetch_related(
@@ -297,41 +327,21 @@ class MediaManager(models.Manager):
 
     def _sort_tv_media_list(self, queryset, sort_filter):
         """Sort TV media list based on the sort criteria."""
+        queryset = self._annotate_tv_media_list(queryset)
+
         if sort_filter == "start_date":
-            # Annotate with the minimum start_date from related seasons/episodes
-            queryset = queryset.annotate(
-                calculated_start_date=models.Min(
-                    "seasons__episodes__end_date",
-                    filter=models.Q(seasons__item__season_number__gt=0),
-                ),
-            )
             return queryset.order_by(
                 models.F("calculated_start_date").asc(nulls_last=True),
                 models.functions.Lower("item__title"),
             )
 
         if sort_filter == "end_date":
-            # Annotate with the maximum end_date from related seasons/episodes
-            queryset = queryset.annotate(
-                calculated_end_date=models.Max(
-                    "seasons__episodes__end_date",
-                    filter=models.Q(seasons__item__season_number__gt=0),
-                ),
-            )
             return queryset.order_by(
                 models.F("calculated_end_date").desc(nulls_last=True),
                 models.functions.Lower("item__title"),
             )
 
         if sort_filter == "progress":
-            # Annotate with the sum of episodes watched (excluding season 0)
-            queryset = queryset.annotate(
-                # Count episodes in regular seasons (season_number > 0)
-                calculated_progress=models.Count(
-                    "seasons__episodes",
-                    filter=models.Q(seasons__item__season_number__gt=0),
-                ),
-            )
             return queryset.order_by(
                 "-calculated_progress",
                 models.functions.Lower("item__title"),
@@ -339,6 +349,24 @@ class MediaManager(models.Manager):
 
         # Default to generic sorting
         return self._sort_generic_media_list(queryset, sort_filter)
+
+    def _annotate_tv_media_list(self, queryset):
+        """Annotate TV list rollups used by media cards and list sorting."""
+        regular_season_filter = models.Q(seasons__item__season_number__gt=0)
+        return queryset.annotate(
+            calculated_progress=models.Count(
+                "seasons__episodes",
+                filter=regular_season_filter,
+            ),
+            calculated_start_date=models.Min(
+                "seasons__episodes__end_date",
+                filter=regular_season_filter,
+            ),
+            calculated_end_date=models.Max(
+                "seasons__episodes__end_date",
+                filter=regular_season_filter,
+            ),
+        )
 
     def _sort_season_media_list(self, queryset, sort_filter):
         """Sort Season media list based on the sort criteria."""
@@ -422,19 +450,41 @@ class MediaManager(models.Manager):
         media_types = self._get_media_types_to_process(user, specific_media_type)
 
         for media_type in media_types:
+            current_time = timezone.now()
+            if items_limit is not None and sort_by in (
+                users.models.HomeSortChoices.RECENT,
+                users.models.HomeSortChoices.TITLE,
+            ):
+                home_page = self._get_limited_home_media(
+                    user=user,
+                    media_type=media_type,
+                    status=status,
+                    sort_by=sort_by,
+                    items_limit=items_limit,
+                    specific_media_type=specific_media_type,
+                    current_time=current_time,
+                )
+                if home_page:
+                    list_by_type[media_type] = home_page
+                continue
+
             # Get base media list for the requested status
             media_list = self.get_media_list(
                 user=user,
                 media_type=media_type,
                 status_filter=status,
                 sort_filter=None,
+                prefetch_events=True,
+                event_queryset=events.models.Event.objects.filter(
+                    datetime__gt=current_time,
+                ).order_by("datetime"),
             )
 
             if not media_list:
                 continue
 
             # Annotate with max_progress and next_event
-            self.annotate_max_progress(media_list, media_type)
+            self.annotate_max_progress(media_list, media_type, current_time)
             self._annotate_next_event(media_list)
 
             # Sort the media list
@@ -456,6 +506,85 @@ class MediaManager(models.Manager):
 
         return list_by_type
 
+    def _get_limited_home_media(
+        self,
+        user,
+        media_type,
+        status,
+        sort_by,
+        items_limit,
+        specific_media_type,
+        current_time,
+    ):
+        """Return a DB-limited home page for sorts that do not need full lists."""
+        queryset = self.get_media_list(
+            user=user,
+            media_type=media_type,
+            status_filter=status,
+            sort_filter=None,
+            prefetch_related=False,
+        )
+        queryset = self._order_limited_home_queryset(queryset, media_type, sort_by)
+
+        total_count = queryset.count()
+        if not total_count:
+            return None
+
+        page_start = items_limit if specific_media_type else 0
+        page_end = None if specific_media_type else items_limit
+        media_list = list(queryset[page_start:page_end])
+        media_list = self._prefetch_home_media(media_list, media_type, current_time)
+        self.annotate_max_progress(media_list, media_type, current_time)
+        self._annotate_next_event(media_list)
+
+        return {
+            "items": media_list,
+            "total": total_count,
+        }
+
+    def _order_limited_home_queryset(self, queryset, media_type, sort_by):
+        """Apply database ordering for limited home-page sorts."""
+        if sort_by == users.models.HomeSortChoices.TITLE:
+            return queryset.order_by(models.functions.Lower("item__title"))
+
+        if media_type == MediaTypes.SEASON.value:
+            queryset = queryset.annotate(
+                calculated_progressed_at=models.Max("episodes__end_date"),
+            )
+            return queryset.order_by(
+                models.F("calculated_progressed_at").desc(nulls_last=True),
+                "-created_at",
+                models.functions.Lower("item__title"),
+            )
+
+        return queryset.order_by(
+            models.F("progressed_at").desc(nulls_last=True),
+            "-created_at",
+            models.functions.Lower("item__title"),
+        )
+
+    def _prefetch_home_media(self, media_list, media_type, current_time):
+        """Prefetch only the objects needed to render a limited home page."""
+        if not media_list:
+            return media_list
+
+        queryset = self._apply_prefetch_related(
+            apps.get_model("app", media_type).objects.filter(
+                id__in=[media.id for media in media_list],
+            ).select_related("item"),
+            media_type,
+            prefetch_events=True,
+            event_queryset=events.models.Event.objects.filter(
+                datetime__gt=current_time,
+            ).order_by("datetime"),
+        )
+        media_by_id = {media.id: media for media in queryset}
+        return [
+            media_by_id[media.id]
+            for media in media_list
+            if media.id in media_by_id
+        ]
+
     def _get_media_types_to_process(self, user, specific_media_type):
         """Determine which media types to process based on user settings."""
         if specific_media_type:
@@ -473,16 +602,12 @@ class MediaManager(models.Manager):
         current_time = timezone.now()
 
         for media in media_list:
-            # Get future events sorted by datetime
-            future_events = sorted(
-                [
-                    event
-                    for event in getattr(media.item, "prefetched_events", [])
-                    if event.datetime > current_time
-                ],
-                key=lambda e: e.datetime,
-            )
-
+            future_events = [
+                event
+                for event in getattr(media.item, "prefetched_events", [])
+                if event.datetime > current_time
+            ]
+            future_events.sort(key=lambda event: event.datetime)
             media.next_event = future_events[0] if future_events else None
 
     def _sort_home_media(self, media_list, sort_by):
@@ -526,9 +651,10 @@ class MediaManager(models.Manager):
             ),
         )
 
-    def annotate_max_progress(self, media_list, media_type):
+    def annotate_max_progress(self, media_list, media_type, current_datetime=None):
         """Annotate max_progress for all media items."""
-        current_datetime = timezone.now()
+        if current_datetime is None:
+            current_datetime = timezone.now()
 
         if media_type == MediaTypes.MOVIE.value:
             for media in media_list:
@@ -572,15 +698,15 @@ class MediaManager(models.Manager):
             item__season_number__gt=0,
             datetime__lte=current_datetime,
             content_number__isnull=False,
-        ).select_related("item")
+        ).values("item__media_id", "item__season_number", "content_number")
 
         # Create a dictionary to store max episode numbers per season per show
         released_episodes = {}
 
         for event in released_events:
-            media_id = event.item.media_id
-            season_number = event.item.season_number
-            episode_number = event.content_number
+            media_id = event["item__media_id"]
+            season_number = event["item__season_number"]
+            episode_number = event["content_number"]
 
             if media_id not in released_episodes:
                 released_episodes[media_id] = {}
@@ -1000,6 +1126,9 @@ class TV(Media):
     @property
     def progress(self):
         """Return the total episodes watched for the TV show."""
+        if hasattr(self, "calculated_progress"):
+            return self.calculated_progress or 0
+
         return sum(
             season.progress
             for season in self.seasons.all()
@@ -1044,6 +1173,9 @@ class TV(Media):
     @property
     def start_date(self):
         """Return the date of the first episode watched."""
+        if hasattr(self, "calculated_start_date"):
+            return self.calculated_start_date
+
         dates = [
             season.start_date
             for season in self.seasons.all()
@@ -1054,6 +1186,9 @@ class TV(Media):
     @property
     def end_date(self):
         """Return the date of the last episode watched."""
+        if hasattr(self, "calculated_end_date"):
+            return self.calculated_end_date
+
         dates = [
             season.end_date
             for season in self.seasons.all()

--- a/src/app/tests/models/test_media_manager.py
+++ b/src/app/tests/models/test_media_manager.py
@@ -313,6 +313,15 @@ class MediaManagerTests(TestCase):
 
         self.assertTrue(hasattr(prefetched_queryset, "_prefetch_related_lookups"))
         prefetch_lookups = prefetched_queryset._prefetch_related_lookups
+        self.assertEqual(len(prefetch_lookups), 1)
+
+        prefetched_queryset = manager._apply_prefetch_related(
+            queryset,
+            MediaTypes.SEASON.value,
+            prefetch_events=True,
+        )
+
+        prefetch_lookups = prefetched_queryset._prefetch_related_lookups
         self.assertEqual(len(prefetch_lookups), 2)
 
         queryset = Movie.objects.filter(user=self.user.id)
@@ -322,6 +331,15 @@ class MediaManagerTests(TestCase):
         )
 
         self.assertTrue(hasattr(prefetched_queryset, "_prefetch_related_lookups"))
+        prefetch_lookups = prefetched_queryset._prefetch_related_lookups
+        self.assertEqual(len(prefetch_lookups), 0)
+
+        prefetched_queryset = manager._apply_prefetch_related(
+            queryset,
+            MediaTypes.MOVIE.value,
+            prefetch_events=True,
+        )
+
         prefetch_lookups = prefetched_queryset._prefetch_related_lookups
         self.assertEqual(len(prefetch_lookups), 1)
 
@@ -336,14 +354,24 @@ class MediaManagerTests(TestCase):
             sort_filter="score",
         )
 
-        tv_list = list(tv_list)
+        tv = tv_list[0]
+
+        with self.assertNumQueries(0):
+            self.assertEqual(tv.progress, 3)
+
+        tv_queryset = TV.objects.filter(user=self.user.id)
+        tv_queryset = manager._apply_prefetch_related(
+            tv_queryset,
+            MediaTypes.TV.value,
+        )
+        tv_list = list(tv_queryset)
 
         for tv in tv_list:
             seasons = list(tv.seasons.all())
             for season in seasons:
                 list(season.episodes.all())
 
-        with self.assertNumQueries(0):  # No additional queries should be made
+        with self.assertNumQueries(0):
             for tv in tv_list:
                 seasons = list(tv.seasons.all())
                 for season in seasons:

--- a/src/config/gunicorn.py
+++ b/src/config/gunicorn.py
@@ -1,5 +1,8 @@
+import os
+
 bind = "localhost:8001"
 preload_app = True
+workers = int(os.environ.get("WEB_CONCURRENCY", "2"))
 timeout = 200
 max_requests = 500
 max_requests_jitter = 10

--- a/src/config/tests/test_gunicorn.py
+++ b/src/config/tests/test_gunicorn.py
@@ -1,3 +1,4 @@
+import importlib
 import sys
 from unittest import mock, skipIf
 
@@ -7,10 +8,35 @@ from django.test import SimpleTestCase
 if sys.platform != "win32":
     from gunicorn.app.wsgiapp import run
 
+DEFAULT_WORKERS = 2
+CUSTOM_WORKERS = 4
+
 
 @skipIf(sys.platform == "win32", "gunicorn is not fully supported on Windows")
 class GunicornConfigTests(SimpleTestCase):
     """Test Gunicorn configuration."""
+
+    def test_workers_default_to_two(self):
+        """Test that Gunicorn starts multiple workers by default."""
+        from config import gunicorn
+
+        with mock.patch.dict("os.environ", {}, clear=True):
+            importlib.reload(gunicorn)
+
+            self.assertEqual(gunicorn.workers, DEFAULT_WORKERS)
+
+        importlib.reload(gunicorn)
+
+    def test_workers_use_web_concurrency(self):
+        """Test that WEB_CONCURRENCY controls the worker count."""
+        from config import gunicorn
+
+        with mock.patch.dict("os.environ", {"WEB_CONCURRENCY": str(CUSTOM_WORKERS)}):
+            importlib.reload(gunicorn)
+
+            self.assertEqual(gunicorn.workers, CUSTOM_WORKERS)
+
+        importlib.reload(gunicorn)
 
     def test_config(self):
         """Test that the Gunicorn configuration file is valid."""

--- a/src/config/tests/test_health.py
+++ b/src/config/tests/test_health.py
@@ -1,0 +1,62 @@
+from http import HTTPStatus
+from unittest import mock
+
+from django.conf import settings
+from django.test import TestCase
+from django.urls import resolve, reverse
+from health_check.views import HealthCheckView
+
+
+class HealthCheckTests(TestCase):
+    """Test health check endpoints."""
+
+    def test_health_check_is_lightweight_and_unauthenticated(self):
+        """Test the default health check skips the deep health check plugins."""
+        redis_client = mock.Mock()
+
+        with (
+            mock.patch("config.views.cache") as cache,
+            mock.patch(
+                "config.views.Redis.from_url",
+                return_value=redis_client,
+            ) as redis_from_url,
+        ):
+            cache.get.return_value = "ok"
+            response = self.client.get(reverse("health"))
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(response.content, b"ok")
+        redis_from_url.assert_called_once_with(
+            settings.REDIS_URL,
+            socket_connect_timeout=1,
+            socket_timeout=1,
+        )
+        redis_client.ping.assert_called_once_with()
+        cache.set.assert_called_once_with("yamtrack:health", "ok", timeout=5)
+        cache.get.assert_called_once_with("yamtrack:health")
+
+        resolved = resolve("/health/")
+        self.assertIsNot(getattr(resolved.func, "view_class", None), HealthCheckView)
+
+    def test_health_check_returns_unavailable_on_cache_failure(self):
+        """Test the fast health check reports dependency failures."""
+        with (
+            mock.patch("config.views.cache") as cache,
+            mock.patch("config.views.Redis.from_url") as redis_from_url,
+        ):
+            cache.get.return_value = None
+            response = self.client.get(reverse("health"))
+
+        self.assertEqual(response.status_code, HTTPStatus.SERVICE_UNAVAILABLE)
+        self.assertEqual(response.content, b"cache unavailable")
+        redis_from_url.return_value.ping.assert_called_once_with()
+
+    def test_full_health_check_keeps_celery_ping(self):
+        """Test the deep django-health-check endpoint is still available."""
+        resolved = resolve("/health/full/")
+
+        self.assertIs(resolved.func.view_class, HealthCheckView)
+        self.assertIn(
+            "health_check.contrib.celery.Ping",
+            resolved.func.view_initkwargs["checks"],
+        )

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -15,6 +15,8 @@ from django.urls import include, path
 from health_check.views import HealthCheckView
 from redis.asyncio import Redis as RedisClient
 
+from config.views import health_check
+
 urlpatterns = [
     path("", include("app.urls")),
     path("", include("integrations.urls")),
@@ -22,8 +24,9 @@ urlpatterns = [
     path("", include("lists.urls")),
     path("", include("events.urls")),
     path("select2/", include("django_select2.urls")),
+    path("health/", login_not_required(health_check), name="health"),
     path(
-        "health/",
+        "health/full/",
         login_not_required(
             HealthCheckView.as_view(
                 checks=[
@@ -41,6 +44,7 @@ urlpatterns = [
                 ]
             )
         ),
+        name="health_full",
     ),
 ]
 

--- a/src/config/views.py
+++ b/src/config/views.py
@@ -1,0 +1,33 @@
+from http import HTTPStatus
+
+from django.conf import settings
+from django.core.cache import cache
+from django.db import DEFAULT_DB_ALIAS, connections
+from django.http import HttpResponse
+from redis import Redis
+
+
+def health_check(_request):
+    """Fast unauthenticated dependency check for container health probes."""
+    try:
+        with connections[DEFAULT_DB_ALIAS].cursor() as cursor:
+            cursor.execute("SELECT 1")
+
+        redis_client = Redis.from_url(
+            settings.REDIS_URL,
+            socket_connect_timeout=1,
+            socket_timeout=1,
+        )
+        redis_client.ping()
+
+        cache_key = "yamtrack:health"
+        cache.set(cache_key, "ok", timeout=5)
+        if cache.get(cache_key) != "ok":
+            return HttpResponse(
+                "cache unavailable",
+                status=HTTPStatus.SERVICE_UNAVAILABLE,
+            )
+    except Exception:  # noqa: BLE001
+        return HttpResponse("unhealthy", status=HTTPStatus.SERVICE_UNAVAILABLE)
+    else:
+        return HttpResponse("ok")


### PR DESCRIPTION
## Summary

- replace the default `/health/` endpoint with a lightweight DB/cache/Redis probe
- keep the Celery-inclusive `django-health-check` endpoint at `/health/full/`
- default Gunicorn to two workers while preserving `WEB_CONCURRENCY` overrides
- stop prefetching item event history for normal non-TV media-list pages
- optimize TV list pages with SQL rollups instead of prefetching every season/episode row
- optimize home-page `recent`/`title` sorts by ordering and slicing in SQL before expensive progress/release annotation
- keep home-page next-release data by opting into a future-only event prefetch
- document the new health endpoint split and add focused tests

## Why

The existing `/health/` endpoint pings Celery, which takes about one second in a local Docker deployment. With the default single Gunicorn worker, routine health probes can occupy the only web worker and make unrelated page loads wait behind them.

For normal media navigation, several pages also built large Python object graphs before slicing/rendering. Non-TV lists prefetched event history that templates do not use directly. TV lists prefetched all seasons and episodes to compute progress/date rollups. The home page built full per-media-type lists before showing the first page of cards. These changes keep the detail-oriented paths available, but make list/home rendering do less work for the common navigation paths.

## Local benchmark

Current image on `127.0.0.1:8000` before the health-check change:

- `/health/`: 5 runs around `1.037s` to `1.066s` TTFB
- `/accounts/login/`: normally around `7ms` to `16ms`, but can queue behind health probes

Patched image on an isolated temporary Docker network at `127.0.0.1:18000` using the same 1 CPU / 1 GiB shape:

- `/health/`: mostly `4ms` to `47ms` TTFB after startup
- `/health/full/`: remains around `1.02s` to `1.13s` TTFB, preserving the deeper Celery check
- `/accounts/login/`: mostly `7ms` to `8ms` TTFB after startup
- process list confirmed two Gunicorn workers by default

Synthetic in-container media-list benchmark with 160 anime records and 1,920 event rows, evaluating a 32-item list page and `annotate_max_progress`:

- patched media-list path: `2` queries, `15.50ms`
- old event-prefetch shape: `3` queries, `26.43ms`

Manual timing on a populated local Yamtrack account with the patched local image:

- Home: before `~4.9s-6.0s`, after `~0.38s-0.65s`
- TV shows: before `~2.5s-3.3s`, after `~0.31s-0.39s`

## Validation

- `python3 -m compileall -q src/app/models.py src/app/tests/models/test_media_manager.py src/config`
- `git diff --check`
- `docker build -t yamtrack-perf:local .`
- `docker run --rm -e SECRET=check-only-secret yamtrack-perf:local python manage.py check`
- `docker run --rm -v "$PWD":/work -w /work -e UV_PROJECT_ENVIRONMENT=/tmp/yamtrack-venv -e UV_CACHE_DIR=/tmp/uv-cache ghcr.io/astral-sh/uv:python3.12-bookworm uv run --group test pytest src/config/tests/test_health.py src/config/tests/test_gunicorn.py`
- `docker run --rm -v "$PWD":/work -w /work -e UV_PROJECT_ENVIRONMENT=/tmp/yamtrack-venv -e UV_CACHE_DIR=/tmp/uv-cache ghcr.io/astral-sh/uv:python3.12-bookworm uv run --group test pytest src/app/tests/models/test_media_manager.py src/app/tests/views/test_home.py`
- `docker run --rm -v "$PWD":/work -w /work -e UV_PROJECT_ENVIRONMENT=/tmp/yamtrack-venv -e UV_CACHE_DIR=/tmp/uv-cache ghcr.io/astral-sh/uv:python3.12-bookworm uv run --group lint ruff check src/app/models.py src/app/tests/models/test_media_manager.py`
