### PR TITLE
Improve mobile UI on small screens

### DIFF
--- a/src/static/css/input.css
+++ b/src/static/css/input.css
@@ -40,6 +40,46 @@
   @apply grid grid-cols-2 xs:grid-cols-[repeat(auto-fill,minmax(180px,1fr))] gap-4;
 }
 
+@media (max-width: 29.99rem) {
+  .media-grid {
+    grid-template-columns: repeat(auto-fill, minmax(min(8.75rem, 100%), 1fr));
+    gap: 0.75rem;
+  }
+}
+
+@media (pointer: coarse) {
+  .media-card-action-overlay {
+    align-items: flex-end;
+    justify-content: flex-end;
+    padding: 0.5rem;
+    background: linear-gradient(to top, rgb(0 0 0 / 0.62), rgb(0 0 0 / 0.08) 55%, transparent);
+    opacity: 1;
+  }
+
+  .media-card-action-overlay > a {
+    display: block;
+  }
+
+  .media-card-actions {
+    gap: 0.5rem;
+  }
+
+  .media-card-action-button {
+    display: inline-flex;
+    width: 2.75rem;
+    height: 2.75rem;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+  }
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .media-card-action-overlay:focus-within {
+    opacity: 1;
+  }
+}
+
 /* https://tailwindcss.com/docs/upgrade-guide#hover-styles-on-mobile */
 @custom-variant hover-tap (&:hover);
 @custom-variant parent-hover-tap (.hover-tap:hover &);

--- a/src/static/css/main.css
+++ b/src/static/css/main.css
@@ -3,10 +3,10 @@
 @layer theme, base, components, utilities;
 @layer theme {
   :root, :host {
-    --font-sans: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
-    'Noto Color Emoji';
-    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
-    monospace;
+    --font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
+      "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+      "Courier New", monospace;
     --color-red-200: oklch(88.5% 0.062 18.334);
     --color-red-300: oklch(80.8% 0.114 19.571);
     --color-red-400: oklch(70.4% 0.191 22.216);
@@ -116,7 +116,7 @@
     line-height: 1.5;
     -webkit-text-size-adjust: 100%;
     tab-size: 4;
-    font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji');
+    font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji");
     font-feature-settings: var(--default-font-feature-settings, normal);
     font-variation-settings: var(--default-font-variation-settings, normal);
     -webkit-tap-highlight-color: transparent;
@@ -143,7 +143,7 @@
     font-weight: bolder;
   }
   code, kbd, samp, pre {
-    font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace);
+    font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
     font-feature-settings: var(--default-mono-font-feature-settings, normal);
     font-variation-settings: var(--default-mono-font-variation-settings, normal);
     font-size: 1em;
@@ -240,13 +240,13 @@
   :-moz-ui-invalid {
     box-shadow: none;
   }
-  button, input:where([type='button'], [type='reset'], [type='submit']), ::file-selector-button {
+  button, input:where([type="button"], [type="reset"], [type="submit"]), ::file-selector-button {
     appearance: button;
   }
   ::-webkit-inner-spin-button, ::-webkit-outer-spin-button {
     height: auto;
   }
-  [hidden]:where(:not([hidden='until-found'])) {
+  [hidden]:where(:not([hidden="until-found"])) {
     display: none !important;
   }
 }
@@ -417,6 +417,9 @@
     @media (width >= 96rem) {
       max-width: 96rem;
     }
+  }
+  .-mx-4 {
+    margin-inline: calc(var(--spacing) * -4);
   }
   .mx-2 {
     margin-inline: calc(var(--spacing) * 2);
@@ -673,6 +676,12 @@
   .max-h-\[300px\] {
     max-height: 300px;
   }
+  .min-h-11 {
+    min-height: calc(var(--spacing) * 11);
+  }
+  .min-h-16 {
+    min-height: calc(var(--spacing) * 16);
+  }
   .min-h-\[130px\] {
     min-height: 130px;
   }
@@ -769,6 +778,12 @@
   .w-\[calc\(100\%-30px\)\] {
     width: calc(100% - 30px);
   }
+  .w-\[min\(100\%\,calc\(100svw-1\.5rem\)\)\] {
+    width: min(100%, calc(100svw - 1.5rem));
+  }
+  .w-auto {
+    width: auto;
+  }
   .w-full {
     width: 100%;
   }
@@ -793,6 +808,9 @@
   .max-w-\[calc\(100\%-2rem\)\] {
     max-width: calc(100% - 2rem);
   }
+  .max-w-\[calc\(100svw-2rem\)\] {
+    max-width: calc(100svw - 2rem);
+  }
   .max-w-\[calc\(100svw-4rem\)\] {
     max-width: calc(100svw - 4rem);
   }
@@ -811,6 +829,9 @@
   .min-w-10 {
     min-width: calc(var(--spacing) * 10);
   }
+  .min-w-11 {
+    min-width: calc(var(--spacing) * 11);
+  }
   .min-w-40 {
     min-width: calc(var(--spacing) * 40);
   }
@@ -822,6 +843,9 @@
   }
   .flex-1 {
     flex: 1;
+  }
+  .flex-none {
+    flex: none;
   }
   .flex-shrink-0 {
     flex-shrink: 0;
@@ -1156,6 +1180,9 @@
   .rounded-md {
     border-radius: var(--radius-md);
   }
+  .rounded-none {
+    border-radius: 0;
+  }
   .rounded-sm {
     border-radius: var(--radius-sm);
   }
@@ -1215,10 +1242,6 @@
   .border-l {
     border-left-style: var(--tw-border-style);
     border-left-width: 1px;
-  }
-  .border-l-2 {
-    border-left-style: var(--tw-border-style);
-    border-left-width: 2px;
   }
   .border-dashed {
     --tw-border-style: dashed;
@@ -1524,6 +1547,9 @@
   .bg-slate-500 {
     background-color: var(--color-slate-500);
   }
+  .bg-transparent {
+    background-color: transparent;
+  }
   .bg-violet-600 {
     background-color: var(--color-violet-600);
   }
@@ -1656,9 +1682,6 @@
   .px-6 {
     padding-inline: calc(var(--spacing) * 6);
   }
-  .px-8 {
-    padding-inline: calc(var(--spacing) * 8);
-  }
   .py-0\.5 {
     padding-block: calc(var(--spacing) * 0.5);
   }
@@ -1677,8 +1700,8 @@
   .py-3 {
     padding-block: calc(var(--spacing) * 3);
   }
-  .py-12 {
-    padding-block: calc(var(--spacing) * 12);
+  .py-6 {
+    padding-block: calc(var(--spacing) * 6);
   }
   .py-16 {
     padding-block: calc(var(--spacing) * 16);
@@ -1724,6 +1747,9 @@
   }
   .pr-12 {
     padding-right: calc(var(--spacing) * 12);
+  }
+  .pb-1 {
+    padding-bottom: calc(var(--spacing) * 1);
   }
   .pb-3 {
     padding-bottom: calc(var(--spacing) * 3);
@@ -1933,9 +1959,6 @@
   }
   .text-yellow-400 {
     color: var(--color-yellow-400);
-  }
-  .capitalize {
-    text-transform: capitalize;
   }
   .uppercase {
     text-transform: uppercase;
@@ -2705,6 +2728,16 @@
       display: none;
     }
   }
+  .xs\:block {
+    @media (width >= 30rem) {
+      display: block;
+    }
+  }
+  .xs\:hidden {
+    @media (width >= 30rem) {
+      display: none;
+    }
+  }
   .sm\:top-2 {
     @media (width >= 40rem) {
       top: calc(var(--spacing) * 2);
@@ -2750,9 +2783,24 @@
       width: calc(var(--spacing) * 32);
     }
   }
+  .sm\:w-auto {
+    @media (width >= 40rem) {
+      width: auto;
+    }
+  }
+  .sm\:max-w-\[calc\(100svw-4rem\)\] {
+    @media (width >= 40rem) {
+      max-width: calc(100svw - 4rem);
+    }
+  }
   .sm\:max-w-none {
     @media (width >= 40rem) {
       max-width: none;
+    }
+  }
+  .sm\:flex-none {
+    @media (width >= 40rem) {
+      flex: none;
     }
   }
   .sm\:grid-cols-2 {
@@ -2800,9 +2848,30 @@
       justify-self: flex-end;
     }
   }
+  .sm\:p-6 {
+    @media (width >= 40rem) {
+      padding: calc(var(--spacing) * 6);
+    }
+  }
   .sm\:px-4 {
     @media (width >= 40rem) {
       padding-inline: calc(var(--spacing) * 4);
+    }
+  }
+  .sm\:px-8 {
+    @media (width >= 40rem) {
+      padding-inline: calc(var(--spacing) * 8);
+    }
+  }
+  .sm\:py-8 {
+    @media (width >= 40rem) {
+      padding-block: calc(var(--spacing) * 8);
+    }
+  }
+  .sm\:text-3xl {
+    @media (width >= 40rem) {
+      font-size: var(--text-3xl);
+      line-height: var(--tw-leading, var(--text-3xl--line-height));
     }
   }
   .sm\:whitespace-normal {
@@ -2823,6 +2892,11 @@
   .md\:mb-8 {
     @media (width >= 48rem) {
       margin-bottom: calc(var(--spacing) * 8);
+    }
+  }
+  .md\:block {
+    @media (width >= 48rem) {
+      display: block;
     }
   }
   .md\:hidden {
@@ -2860,6 +2934,21 @@
       width: calc(var(--spacing) * 64);
     }
   }
+  .md\:w-96 {
+    @media (width >= 48rem) {
+      width: calc(var(--spacing) * 96);
+    }
+  }
+  .md\:w-152 {
+    @media (width >= 48rem) {
+      width: calc(var(--spacing) * 152);
+    }
+  }
+  .md\:w-full {
+    @media (width >= 48rem) {
+      width: 100%;
+    }
+  }
   .md\:max-w-\[250px\] {
     @media (width >= 48rem) {
       max-width: 250px;
@@ -2891,6 +2980,15 @@
       gap: calc(var(--spacing) * 10);
     }
   }
+  .md\:space-y-1 {
+    @media (width >= 48rem) {
+      :where(& > :not(:last-child)) {
+        --tw-space-y-reverse: 0;
+        margin-block-start: calc(calc(var(--spacing) * 1) * var(--tw-space-y-reverse));
+        margin-block-end: calc(calc(var(--spacing) * 1) * calc(1 - var(--tw-space-y-reverse)));
+      }
+    }
+  }
   .md\:gap-y-0 {
     @media (width >= 48rem) {
       row-gap: calc(var(--spacing) * 0);
@@ -2901,9 +2999,46 @@
       overflow-y: auto;
     }
   }
+  .md\:rounded-lg {
+    @media (width >= 48rem) {
+      border-radius: var(--radius-lg);
+    }
+  }
+  .md\:border-b-0 {
+    @media (width >= 48rem) {
+      border-bottom-style: var(--tw-border-style);
+      border-bottom-width: 0px;
+    }
+  }
+  .md\:border-l-2 {
+    @media (width >= 48rem) {
+      border-left-style: var(--tw-border-style);
+      border-left-width: 2px;
+    }
+  }
+  .md\:bg-\[\#2a2f35\] {
+    @media (width >= 48rem) {
+      background-color: #2a2f35;
+    }
+  }
+  .md\:bg-transparent {
+    @media (width >= 48rem) {
+      background-color: transparent;
+    }
+  }
+  .md\:p-2 {
+    @media (width >= 48rem) {
+      padding: calc(var(--spacing) * 2);
+    }
+  }
   .md\:px-0 {
     @media (width >= 48rem) {
       padding-inline: calc(var(--spacing) * 0);
+    }
+  }
+  .md\:px-2 {
+    @media (width >= 48rem) {
+      padding-inline: calc(var(--spacing) * 2);
     }
   }
   .md\:text-start {
@@ -2967,6 +3102,11 @@
       justify-content: center;
     }
   }
+  .lg\:py-12 {
+    @media (width >= 64rem) {
+      padding-block: calc(var(--spacing) * 12);
+    }
+  }
   .lg\:pb-40 {
     @media (width >= 64rem) {
       padding-bottom: calc(var(--spacing) * 40);
@@ -2985,11 +3125,6 @@
   .\@max-\[210px\]\:flex-col {
     @container (width < 210px) {
       flex-direction: column;
-    }
-  }
-  .pointer-coarse\:hidden {
-    @media (pointer: coarse) {
-      display: none;
     }
   }
   .hover-tap\:opacity-100 {
@@ -3046,6 +3181,40 @@
   gap: calc(var(--spacing) * 4);
   @media (width >= 30rem) {
     grid-template-columns: repeat(auto-fill,minmax(180px,1fr));
+  }
+}
+@media (max-width: 29.99rem) {
+  .media-grid {
+    grid-template-columns: repeat(auto-fill, minmax(min(8.75rem, 100%), 1fr));
+    gap: 0.75rem;
+  }
+}
+@media (pointer: coarse) {
+  .media-card-action-overlay {
+    align-items: flex-end;
+    justify-content: flex-end;
+    padding: 0.5rem;
+    background: linear-gradient(to top, rgb(0 0 0 / 0.62), rgb(0 0 0 / 0.08) 55%, transparent);
+    opacity: 1;
+  }
+  .media-card-action-overlay > a {
+    display: block;
+  }
+  .media-card-actions {
+    gap: 0.5rem;
+  }
+  .media-card-action-button {
+    display: inline-flex;
+    width: 2.75rem;
+    height: 2.75rem;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+  }
+}
+@media (hover: hover) and (pointer: fine) {
+  .media-card-action-overlay:focus-within {
+    opacity: 1;
   }
 }
 .toast-error {

--- a/src/templates/app/components/home_grid.html
+++ b/src/templates/app/components/home_grid.html
@@ -31,11 +31,11 @@
         </div>
       {% endif %}
 
-      <div class="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 hover-tap:opacity-100{% if user.clickable_media_cards %} pointer-coarse:hidden{% endif %}">
+      <div class="media-card-action-overlay absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 hover-tap:opacity-100">
         <a href="{{ media.item|media_url }}" class="absolute inset-0 z-0"></a>
 
-        <div class="relative z-10 flex items-center justify-center space-x-2.5">
-          <button class="cursor-pointer rounded-full bg-indigo-600 p-2.5 text-white transition-all duration-200 hover:scale-110 hover:bg-indigo-500 hover:shadow-[0_0_15px_rgba(99,102,241,0.5)]"
+        <div class="media-card-actions relative z-10 flex items-center justify-center space-x-2.5">
+          <button class="media-card-action-button cursor-pointer rounded-full bg-indigo-600 p-2.5 text-white transition-all duration-200 hover:scale-110 hover:bg-indigo-500 hover:shadow-[0_0_15px_rgba(99,102,241,0.5)]"
                   title="Add to tracker"
                   hx-get="{% media_view_url 'track_modal' media.item %}"
                   hx-vals='{"return_url": "{{ request.get_full_path|urlencode }}", "instance_id": "{{ media.id }}"}'
@@ -43,7 +43,7 @@
                   hx-trigger="click once"
                   @click="trackOpen = true">{% include "app/icons/edit.svg" with classes="w-4 h-4" %}</button>
 
-          <button class="cursor-pointer rounded-full bg-emerald-600 p-2.5 text-white transition-all duration-200 hover:scale-110 hover:bg-emerald-500 hover:shadow-[0_0_15px_rgba(16,185,129,0.5)]"
+          <button class="media-card-action-button cursor-pointer rounded-full bg-emerald-600 p-2.5 text-white transition-all duration-200 hover:scale-110 hover:bg-emerald-500 hover:shadow-[0_0_15px_rgba(16,185,129,0.5)]"
                   title="Add to custom lists"
                   hx-get="{% media_view_url 'lists_modal' media.item %}"
                   hx-vals='{"return_url": "{{ request.get_full_path|urlencode }}"}'
@@ -51,7 +51,7 @@
                   hx-trigger="click once"
                   @click="listsOpen = true">{% include "app/icons/list-add.svg" with classes="w-4 h-4" %}</button>
 
-          <button class="cursor-pointer rounded-full bg-amber-600 p-2.5 text-white transition-all duration-200 hover:scale-110 hover:bg-amber-500 hover:shadow-[0_0_15px_rgba(245,158,11,0.5)]"
+          <button class="media-card-action-button cursor-pointer rounded-full bg-amber-600 p-2.5 text-white transition-all duration-200 hover:scale-110 hover:bg-amber-500 hover:shadow-[0_0_15px_rgba(245,158,11,0.5)]"
                   title="View your activity history"
                   hx-get="{% media_view_url 'history_modal' media.item %}"
                   hx-vals='{"return_url": "{{ request.get_full_path|urlencode }}"}'
@@ -79,7 +79,7 @@
     <div x-show="trackOpen"
          @keydown.escape.window="trackOpen = false"
          class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div class="relative z-60 max-h-[90vh] w-152 px-4 md:px-0"
+      <div class="relative z-60 max-h-[90vh] w-[min(100%,calc(100svw-1.5rem))] px-4 md:w-152 md:px-0"
            @click.outside="trackOpen = false">
         <div id="{{ track_component_id }}"></div>
       </div>
@@ -88,7 +88,7 @@
     <div x-show="listsOpen"
          @keydown.escape.window="listsOpen = false"
          class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div class="relative z-60 max-h-[90vh] w-96 px-4 md:px-0"
+      <div class="relative z-60 max-h-[90vh] w-[min(100%,calc(100svw-1.5rem))] px-4 md:w-96 md:px-0"
            @click.outside="listsOpen = false">
         <div id="{{ lists_component_id }}"></div>
       </div>
@@ -97,7 +97,7 @@
     <div x-show="historyOpen"
          @keydown.escape.window="historyOpen = false"
          class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div class="relative z-60 max-h-[90vh] w-96 px-4 md:px-0"
+      <div class="relative z-60 max-h-[90vh] w-[min(100%,calc(100svw-1.5rem))] px-4 md:w-96 md:px-0"
            @click.outside="historyOpen = false">
         <div id="{{ history_component_id }}"></div>
       </div>

--- a/src/templates/app/components/media_card.html
+++ b/src/templates/app/components/media_card.html
@@ -52,13 +52,13 @@
     {% endif %}
 
     {% with user=target_user|default:user %}
-      <div class="absolute inset-0 bg-black/50 flex items-center justify-center opacity-0 hover-tap:opacity-100{% if user.clickable_media_cards %} pointer-coarse:hidden{% endif %}">
-        <a href="{{ item|media_url }}" class="absolute inset-0"></a>
+      <div class="media-card-action-overlay absolute inset-0 bg-black/50 flex items-center justify-center opacity-0 hover-tap:opacity-100">
+        <a href="{{ item|media_url }}" class="absolute inset-0 z-0"></a>
         {% if request.user == user %}
-          <div class="relative flex items-center justify-center space-x-2.5">
+          <div class="media-card-actions relative z-10 flex items-center justify-center space-x-2.5">
             {% if item.media_type == MediaTypes.EPISODE.value %}
               <button @click="trackOpen = true"
-                      class="p-2.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-full hover:scale-110 hover:shadow-[0_0_15px_rgba(99,102,241,0.5)] transition-all duration-200 cursor-pointer">
+                      class="media-card-action-button p-2.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-full hover:scale-110 hover:shadow-[0_0_15px_rgba(99,102,241,0.5)] transition-all duration-200 cursor-pointer">
                 {% if media %}
                   {% include "app/icons/eye.svg" with classes="w-4 h-4" %}
                 {% else %}
@@ -67,7 +67,7 @@
               </button>
             {% else %}
               {# Track Button #}
-              <button class="p-2.5 bg-indigo-600 text-white rounded-full hover:bg-indigo-500 hover:scale-110 hover:shadow-[0_0_15px_rgba(99,102,241,0.5)] transition-all duration-200 cursor-pointer"
+              <button class="media-card-action-button p-2.5 bg-indigo-600 text-white rounded-full hover:bg-indigo-500 hover:scale-110 hover:shadow-[0_0_15px_rgba(99,102,241,0.5)] transition-all duration-200 cursor-pointer"
                       title="Add to tracker"
                       hx-get="{% media_view_url 'track_modal' item %}"
                       hx-vals='{"return_url": "{{ request.get_full_path|urlencode }}", "instance_id": "{{ media.id }}"}'
@@ -77,7 +77,7 @@
             {% endif %}
 
             {# Lists Button #}
-            <button class="p-2.5 bg-emerald-600 text-white rounded-full hover:bg-emerald-500 hover:scale-110 hover:shadow-[0_0_15px_rgba(16,185,129,0.5)] transition-all duration-200 cursor-pointer"
+            <button class="media-card-action-button p-2.5 bg-emerald-600 text-white rounded-full hover:bg-emerald-500 hover:scale-110 hover:shadow-[0_0_15px_rgba(16,185,129,0.5)] transition-all duration-200 cursor-pointer"
                     title="Add to custom lists"
                     hx-get="{% media_view_url 'lists_modal' item %}"
                     hx-vals='{"return_url": "{{ request.get_full_path|urlencode }}"}'
@@ -86,7 +86,7 @@
                     @click="listsOpen = true">{% include "app/icons/list-add.svg" with classes="w-4 h-4" %}</button>
 
             {# History Button #}
-            <button class="p-2.5 bg-amber-600 text-white rounded-full hover:bg-amber-500 hover:scale-110 hover:shadow-[0_0_15px_rgba(245,158,11,0.5)] transition-all duration-200 cursor-pointer"
+            <button class="media-card-action-button p-2.5 bg-amber-600 text-white rounded-full hover:bg-amber-500 hover:scale-110 hover:shadow-[0_0_15px_rgba(245,158,11,0.5)] transition-all duration-200 cursor-pointer"
                     title="View your activity history"
                     hx-get="{% media_view_url 'history_modal' item %}"
                     hx-vals='{"return_url": "{{ request.get_full_path|urlencode }}"}'
@@ -112,7 +112,7 @@
     <div x-show="trackOpen"
          @keydown.escape.window="trackOpen = false"
          class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div class="w-152 max-h-[90vh] px-4 md:px-0 relative z-60"
+      <div class="w-[min(100%,calc(100svw-1.5rem))] max-h-[90vh] px-4 md:w-152 md:px-0 relative z-60"
            @click.outside="trackOpen = false">
         <div id="{% component_id 'track' item media.id %}"></div>
       </div>
@@ -123,7 +123,7 @@
   <div x-show="listsOpen"
        @keydown.escape.window="listsOpen = false"
        class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-    <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60"
+    <div class="w-[min(100%,calc(100svw-1.5rem))] max-h-[90vh] px-4 md:w-96 md:px-0 relative z-60"
          @click.outside="listsOpen = false">
       <div id="{% component_id 'lists' item %}"></div>
     </div>
@@ -133,7 +133,7 @@
   <div x-show="historyOpen"
        @keydown.escape.window="historyOpen = false"
        class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-    <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60"
+    <div class="w-[min(100%,calc(100svw-1.5rem))] max-h-[90vh] px-4 md:w-96 md:px-0 relative z-60"
          @click.outside="historyOpen = false">
       <div id="{% component_id 'history' item %}"></div>
     </div>

--- a/src/templates/app/components/media_table_items.html
+++ b/src/templates/app/components/media_table_items.html
@@ -21,7 +21,7 @@
         <div x-show="trackOpen"
              @keydown.escape.window="trackOpen = false"
              class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div class="w-152 max-h-[90vh] px-4 md:px-0 relative z-60"
+          <div class="w-[min(100%,calc(100svw-1.5rem))] max-h-[90vh] px-4 md:w-152 md:px-0 relative z-60"
                @click.outside="trackOpen = false">
             <div id="{% component_id 'track' media.item media.id %}"></div>
           </div>

--- a/src/templates/app/home.html
+++ b/src/templates/app/home.html
@@ -8,17 +8,17 @@
 {% block content %}
   <div class="space-y-8">
     <div class="flex flex-col gap-4 sm:grid sm:grid-cols-[1fr_auto_1fr] sm:items-center">
-      <h1 class="text-3xl font-bold text-center sm:col-start-2 sm:justify-self-center">Home</h1>
-      <div class="flex flex-wrap items-center justify-center gap-3 sm:col-start-3 sm:justify-self-end">
+      <h1 class="text-center text-2xl font-bold sm:col-start-2 sm:justify-self-center sm:text-3xl">Home</h1>
+      <div class="flex w-full flex-wrap items-center justify-center gap-3 sm:col-start-3 sm:w-auto sm:justify-self-end">
         <a href="{% url 'home' %}?sort={{ current_sort }}{% if hide_unreleased %}&hide_unreleased=false{% else %}&hide_unreleased=true{% endif %}"
-           class="inline-flex items-center gap-2 rounded-md border px-4 py-2 text-sm font-medium transition-colors {% if hide_unreleased %}border-indigo-500 bg-indigo-600 text-white hover:bg-indigo-700{% else %}border-gray-700 bg-[#39404b] text-gray-300 hover:bg-[#454d5a] hover:text-white{% endif %}">
+           class="inline-flex min-h-11 flex-1 items-center justify-center gap-2 rounded-md border px-4 py-2 text-sm font-medium transition-colors sm:flex-none {% if hide_unreleased %}border-indigo-500 bg-indigo-600 text-white hover:bg-indigo-700{% else %}border-gray-700 bg-[#39404b] text-gray-300 hover:bg-[#454d5a] hover:text-white{% endif %}">
           {% include "app/icons/eye-closed.svg" with classes="w-4 h-4" %}
           <span>Hide unreleased</span>
         </a>
         <div class="relative" x-data="{ open: false }">
           <button @click="open = !open"
                   @click.outside="open = false"
-                  class="flex items-center gap-2 rounded-md border border-gray-700 bg-[#39404b] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[#454d5a] cursor-pointer">
+                  class="flex min-h-11 flex-1 items-center justify-center gap-2 rounded-md border border-gray-700 bg-[#39404b] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[#454d5a] cursor-pointer sm:flex-none">
             {% include "app/icons/arrows-up-down.svg" with classes="w-4 h-4" %}
             <span>{{ current_sort|no_underscore|title }}</span>
             {% include "app/icons/chevron-down.svg" with classes="w-4 h-4 text-gray-400" %}

--- a/src/templates/app/media_list.html
+++ b/src/templates/app/media_list.html
@@ -8,7 +8,7 @@
 {% endblock title %}
 
 {% block content %}
-  <h1 class="text-3xl font-bold mb-6">
+  <h1 class="mb-6 text-2xl font-bold sm:text-3xl">
     {% if request.user != target_user %}{{ target_user.username }}'s{% endif %}
     {{ media_type|media_type_readable_plural }}
   </h1>
@@ -35,11 +35,11 @@
       <input type="hidden" name="layout" x-model="layout">
     </form>
 
-    <div class="flex flex-col md:flex-row gap-4 mb-6">
+    <div class="mb-6 flex flex-col gap-4 md:flex-row">
       <!-- Search -->
       <div class="relative grow">
         <input placeholder="Search {{ media_type_plural }} in {% if target_user != request.user %}{{ target_user.username }}'s {% else %}your {% endif %}list..."
-               class="w-full py-2 pl-10 pr-4 bg-[#39404b] rounded-md text-white focus:outline-none focus:ring-2 focus:ring-[#4a9eff] appearance-none"
+               class="min-h-11 w-full rounded-md bg-[#39404b] py-2 pl-10 pr-4 text-white appearance-none focus:outline-none focus:ring-2 focus:ring-[#4a9eff]"
                type="text"
                x-model="search"
                hx-get="{% url 'medialist' target_user.username media_type %}"
@@ -54,10 +54,10 @@
         </div>
       </div>
 
-      <div class="flex gap-2 flex-wrap">
+      <div class="flex w-full flex-wrap gap-2 sm:w-auto">
         <!-- Filter by Status -->
-        <div class="relative" x-data="{ open: false }">
-          <button class="flex items-center px-4 py-2 bg-[#39404b] rounded-md hover:bg-[#454d5a] transition-colors cursor-pointer"
+        <div class="relative flex-1 sm:flex-none" x-data="{ open: false }">
+          <button class="flex min-h-11 w-full items-center justify-center rounded-md bg-[#39404b] px-4 py-2 transition-colors hover:bg-[#454d5a] cursor-pointer"
                   @click="open = !open"
                   type="button">
             {% include "app/icons/funnel.svg" with classes="w-4 h-4 mr-2" %}
@@ -89,8 +89,8 @@
         </div>
 
         <!-- Sort by -->
-        <div class="relative" x-data="{ open: false }">
-          <button class="flex items-center px-4 py-2 bg-[#39404b] rounded-md hover:bg-[#454d5a] transition-colors cursor-pointer"
+        <div class="relative flex-1 sm:flex-none" x-data="{ open: false }">
+          <button class="flex min-h-11 w-full items-center justify-center rounded-md bg-[#39404b] px-4 py-2 transition-colors hover:bg-[#454d5a] cursor-pointer"
                   @click="open = !open"
                   type="button">
             {% include "app/icons/arrows-up-down.svg" with classes="w-4 h-4 mr-2" %}
@@ -122,14 +122,14 @@
         </div>
 
         <!-- Layout Toggle -->
-        <div class="flex rounded-md overflow-hidden border border-gray-700">
+        <div class="flex w-full rounded-md overflow-hidden border border-gray-700 sm:w-auto">
           <a :href="`{% url 'medialist' target_user.username media_type %}?${search ? 'search=' + search + '&' : ''}${status !== 'all' ? 'status=' + status + '&' : ''}${sort !== 'score' ? 'sort=' + sort + '&' : ''}layout=grid`"
-             class="p-2 cursor-pointer"
+             class="inline-flex min-h-11 flex-1 items-center justify-center p-2 cursor-pointer"
              :class="layout === 'grid' ? 'bg-indigo-600 text-white' : 'bg-[#39404b] hover:bg-[#454d5a]'"
              title="Grid View"
              @click="layout = 'grid'">{% include "app/icons/four-square.svg" with classes="w-5 h-5" %}</a>
           <a :href="`{% url 'medialist' target_user.username media_type %}?${search ? 'search=' + search + '&' : ''}${status !== 'all' ? 'status=' + status + '&' : ''}${sort !== 'score' ? 'sort=' + sort + '&' : ''}layout=table`"
-             class="p-2 cursor-pointer"
+             class="inline-flex min-h-11 flex-1 items-center justify-center p-2 cursor-pointer"
              :class="layout === 'table' ? 'bg-indigo-600 text-white' : 'bg-[#39404b] hover:bg-[#454d5a]'"
              title="Table View"
              @click="layout = 'table'">{% include "app/icons/table.svg" with classes="w-5 h-5" %}</a>
@@ -159,7 +159,7 @@
     {% elif current_layout == "grid" %}
       <div class="media-grid">{% include "app/components/media_grid_items.html" %}</div>
     {% else %}
-      <div class="bg-[#2a2f35] p-4 rounded-lg overflow-hidden max-w-[calc(100svw-4rem)] overflow-x-scroll">
+      <div class="max-w-[calc(100svw-2rem)] overflow-x-scroll rounded-lg bg-[#2a2f35] p-4 sm:max-w-[calc(100svw-4rem)]">
         <table class="w-full bg-[#2a2f35]">
           <thead class="text-left text-gray-400 text-sm">
             <tr>

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -236,10 +236,12 @@
           {# Top bar #}
           <div class="sticky top-0 z-10 bg-[#1a1d20] border-b border-[#2c3136] shadow-md">
             <div class="container mx-auto px-4">
-              <div class="flex items-center justify-between lg:justify-center h-16">
+              <div class="flex min-h-16 items-center justify-between lg:justify-center">
                 {# Mobile: sidebar toggle button #}
                 <button @click="isMobileMenuOpen = !isMobileMenuOpen"
-                        class="lg:hidden pe-3 text-gray-400 hover:text-white transition-colors duration-200">
+                        class="flex min-h-11 min-w-11 items-center justify-center pe-3 text-gray-400 transition-colors duration-200 hover:text-white lg:hidden"
+                        type="button"
+                        aria-label="Open navigation menu">
                   {% include "app/icons/hamburger.svg" with classes="w-6 h-6" %}
 
                 </button>
@@ -265,7 +267,7 @@
                                  name="q"
                                  value="{{ request.GET.q }}"
                                  :placeholder="getPlaceholder()"
-                                 class="w-full py-2 pl-10 pr-4 text-sm text-gray-300 bg-[#272c31] rounded-l-md focus:outline-none focus:ring-2 focus:ring-[#4a9eff] focus:ring-inset placeholder-gray-500">
+                                 class="min-h-11 w-full rounded-l-md bg-[#272c31] py-2 pl-10 pr-4 text-sm text-gray-300 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#4a9eff] focus:ring-inset">
                           <button type="submit"
                                   class="absolute left-2 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-white transition-colors duration-200 focus:outline-none cursor-pointer">
                             {% include "app/icons/magnifying-glass.svg" with classes="w-5 h-5" %}
@@ -279,7 +281,7 @@
                         <button type="button"
                                 @click="isOpen = !isOpen"
                                 @click.away="isOpen = false"
-                                class="flex items-center justify-between max-w-[110px] sm:max-w-none sm:w-32 px-2 sm:px-4 py-2 text-sm text-gray-300 bg-[#272c31] rounded-r-md focus:outline-none focus:ring-2 focus:ring-[#4a9eff] focus:ring-inset hover:bg-[#2a2e33] transition-colors duration-200 cursor-pointer">
+                                class="flex min-h-11 max-w-[110px] cursor-pointer items-center justify-between rounded-r-md bg-[#272c31] px-2 py-2 text-sm text-gray-300 transition-colors duration-200 hover:bg-[#2a2e33] focus:outline-none focus:ring-2 focus:ring-[#4a9eff] focus:ring-inset sm:w-32 sm:max-w-none sm:px-4">
                           <span class="truncate sm:whitespace-normal" x-text="selectedType.display"></span>
                           {% include "app/icons/chevron-down.svg" with classes="w-4 h-4 ml-2" %}
 
@@ -309,7 +311,7 @@
           </div>
 
           <main class="flex-1 relative bg-[#212529]">
-            <div class="container mx-auto px-8 py-12">
+            <div class="container mx-auto px-4 py-6 sm:px-8 sm:py-8 lg:py-12">
               {% block content %}
               {% endblock content %}
             </div>

--- a/src/templates/events/calendar.html
+++ b/src/templates/events/calendar.html
@@ -7,12 +7,12 @@
 
 {% block content %}
   <div class="mb-8">
-    <h1 class="text-3xl font-bold mb-2">Calendar</h1>
+    <h1 class="mb-2 text-2xl font-bold sm:text-3xl">Calendar</h1>
     <p class="text-gray-400">Track upcoming releases from your list.</p>
   </div>
 
-  <div class="bg-[#2a2f35] rounded-lg p-6 mb-6">
-    <div class="flex flex-col sm:flex-row justify-between items-center mb-6 gap-4">
+  <div class="mb-6 rounded-lg bg-[#2a2f35] p-4 sm:p-6">
+    <div class="mb-6 flex flex-col items-center justify-between gap-4 sm:flex-row">
       <div class="flex items-center gap-4">
         <div class="flex items-center bg-[#39404b] rounded-md p-1">
           <a class="p-2 hover:bg-[#454d5a] rounded-md transition-colors"
@@ -27,20 +27,22 @@
         </div>
       </div>
 
-      <div class="flex items-center gap-2">
-        <a class="px-4 py-2 text-sm bg-[#39404b] hover:bg-[#454d5a] rounded-md transition-colors"
+      <div class="flex w-full flex-wrap items-center gap-2 sm:w-auto">
+        <a class="inline-flex min-h-11 flex-1 items-center justify-center rounded-md bg-[#39404b] px-4 py-2 text-sm transition-colors hover:bg-[#454d5a] sm:flex-none"
            href="{% url 'calendar' %}?month={{ today.month }}&year={{ today.year }}&view={{ view_type }}">Today</a>
 
-        <form method="post" action="{% url 'reload_calendar' %}">
+        <form method="post"
+              action="{% url 'reload_calendar' %}"
+              class="flex-1 sm:flex-none">
           {% csrf_token %}
-          <button class="px-4 py-2 text-sm bg-[#39404b] hover:bg-[#454d5a] rounded-md transition-colors flex items-center gap-2 cursor-pointer">
+          <button class="flex min-h-11 w-full items-center justify-center gap-2 rounded-md bg-[#39404b] px-4 py-2 text-sm transition-colors hover:bg-[#454d5a] cursor-pointer">
             {% include "app/icons/circle-spinning-clockwise.svg" with classes="w-4 h-4" %}
             <span>Fetch New Releases</span>
           </button>
         </form>
 
-        <div class="bg-[#39404b] rounded-md p-1 space-x-0.5 flex">
-          <a class="p-2 rounded-md transition-colors cursor-pointer {% if view_type == 'grid' %}bg-indigo-600 text-white{% else %}hover:bg-[#454d5a]{% endif %}"
+        <div class="flex rounded-md bg-[#39404b] p-1 space-x-0.5">
+          <a class="hidden rounded-md p-2 transition-colors cursor-pointer xs:block {% if view_type == 'grid' %}bg-indigo-600 text-white{% else %}hover:bg-[#454d5a]{% endif %}"
              href="{% url 'calendar' %}?month={{ month }}&year={{ year }}&view=grid">
             {% include "app/icons/grid.svg" with classes="w-4 h-4" %}
           </a>
@@ -50,18 +52,21 @@
           </a>
         </div>
 
-        <a class="p-3 text-sm bg-[#39404b] hover:bg-[#454d5a] rounded-md transition-colors"
+        <a class="inline-flex min-h-11 flex-none items-center justify-center rounded-md bg-[#39404b] p-3 text-sm transition-colors hover:bg-[#454d5a]"
            href="{% url 'download_calendar' token=user.token %}">
           {% include "app/icons/download.svg" with classes="w-4 h-4" %}
         </a>
       </div>
     </div>
 
-    {% if view_type == 'grid' %}
-      {% include "events/components/calendar_grid.html" %}
-    {% else %}
-      {% include "events/components/calendar_list.html" %}
-    {% endif %}
+    <div class="{% if view_type == 'grid' %}calendar-grid-view{% endif %}">
+      {% if view_type == 'grid' %}
+        <div class="hidden xs:block">{% include "events/components/calendar_grid.html" %}</div>
+        <div class="xs:hidden">{% include "events/components/calendar_list.html" %}</div>
+      {% else %}
+        {% include "events/components/calendar_list.html" %}
+      {% endif %}
+    </div>
   </div>
 
   <div class="bg-[#2a2f35] p-5 rounded-lg mb-6">

--- a/src/templates/users/base.html
+++ b/src/templates/users/base.html
@@ -9,60 +9,60 @@
     </div>
     <div class="flex flex-col md:flex-row gap-8">
       <div class="md:w-64 shrink-0">
-        <div class="bg-[#2a2f35] rounded-lg overflow-hidden sticky top-20">
-          <nav class="p-2 space-y-1">
+        <div class="sticky top-20 -mx-4 overflow-hidden rounded-none bg-transparent md:mx-0 md:rounded-lg md:bg-[#2a2f35]">
+          <nav class="flex gap-2 overflow-x-auto px-4 pb-1 md:block md:space-y-1 md:p-2">
             {% url 'account' as account_url %}
             <a href="{{ account_url }}"
-               class="w-full flex items-center space-x-3 px-2 py-2 rounded-md transition-colors text-left border-l-2 cursor-pointer text-sm {% if request.path == account_url %}bg-[#39404b] text-white border-indigo-500{% else %}text-gray-400 border-transparent hover:bg-[#313842] hover:text-white{% endif %}">
+               class="flex min-h-11 w-auto flex-none items-center space-x-3 rounded-md border-b-2 px-3 py-2 text-left text-sm transition-colors cursor-pointer md:w-full md:border-b-0 md:border-l-2 md:px-2 {% if request.path == account_url %}bg-[#39404b] text-white border-indigo-500{% else %}bg-[#2a2f35] text-gray-400 border-transparent hover:bg-[#313842] hover:text-white md:bg-transparent{% endif %}">
               {% include "app/icons/person.svg" with classes="w-5 h-5" %}
               <span>Account</span>
             </a>
 
             {% url 'preferences' as preferences_url %}
             <a href="{{ preferences_url }}"
-               class="w-full flex items-center space-x-3 px-2 py-2 rounded-md transition-colors text-left border-l-2 cursor-pointer text-sm {% if request.path == preferences_url %}bg-[#39404b] text-white border-indigo-500{% else %}text-gray-400 border-transparent hover:bg-[#313842] hover:text-white{% endif %}">
+               class="flex min-h-11 w-auto flex-none items-center space-x-3 rounded-md border-b-2 px-3 py-2 text-left text-sm transition-colors cursor-pointer md:w-full md:border-b-0 md:border-l-2 md:px-2 {% if request.path == preferences_url %}bg-[#39404b] text-white border-indigo-500{% else %}bg-[#2a2f35] text-gray-400 border-transparent hover:bg-[#313842] hover:text-white md:bg-transparent{% endif %}">
               {% include "app/icons/vertical-sliders.svg" with classes="w-5 h-5" %}
               <span>Preferences</span>
             </a>
 
             {% url 'notifications' as notifications_url %}
             <a href="{{ notifications_url }}"
-               class="w-full flex items-center space-x-3 px-2 py-2 rounded-md transition-colors text-left border-l-2 cursor-pointer text-sm {% if request.path == notifications_url %}bg-[#39404b] text-white border-indigo-500{% else %}text-gray-400 border-transparent hover:bg-[#313842] hover:text-white{% endif %}">
+               class="flex min-h-11 w-auto flex-none items-center space-x-3 rounded-md border-b-2 px-3 py-2 text-left text-sm transition-colors cursor-pointer md:w-full md:border-b-0 md:border-l-2 md:px-2 {% if request.path == notifications_url %}bg-[#39404b] text-white border-indigo-500{% else %}bg-[#2a2f35] text-gray-400 border-transparent hover:bg-[#313842] hover:text-white md:bg-transparent{% endif %}">
               {% include "app/icons/bell.svg" with classes="w-5 h-5" %}
               <span>Notifications</span>
             </a>
 
             {% url 'integrations' as integrations_url %}
             <a href="{{ integrations_url }}"
-               class="w-full flex items-center space-x-3 px-2 py-2 rounded-md transition-colors text-left border-l-2 cursor-pointer text-sm {% if request.path == integrations_url %}bg-[#39404b] text-white border-indigo-500{% else %}text-gray-400 border-transparent hover:bg-[#313842] hover:text-white{% endif %}">
+               class="flex min-h-11 w-auto flex-none items-center space-x-3 rounded-md border-b-2 px-3 py-2 text-left text-sm transition-colors cursor-pointer md:w-full md:border-b-0 md:border-l-2 md:px-2 {% if request.path == integrations_url %}bg-[#39404b] text-white border-indigo-500{% else %}bg-[#2a2f35] text-gray-400 border-transparent hover:bg-[#313842] hover:text-white md:bg-transparent{% endif %}">
               {% include "app/icons/database.svg" with classes="w-5 h-5" %}
               <span>Integrations</span>
             </a>
 
             {% url 'import_data' as import_url %}
             <a href="{{ import_url }}"
-               class="w-full flex items-center space-x-3 px-2 py-2 rounded-md transition-colors text-left border-l-2 cursor-pointer text-sm {% if request.path == import_url %}bg-[#39404b] text-white border-indigo-500{% else %}text-gray-400 border-transparent hover:bg-[#313842] hover:text-white{% endif %}">
+               class="flex min-h-11 w-auto flex-none items-center space-x-3 rounded-md border-b-2 px-3 py-2 text-left text-sm transition-colors cursor-pointer md:w-full md:border-b-0 md:border-l-2 md:px-2 {% if request.path == import_url %}bg-[#39404b] text-white border-indigo-500{% else %}bg-[#2a2f35] text-gray-400 border-transparent hover:bg-[#313842] hover:text-white md:bg-transparent{% endif %}">
               {% include "app/icons/import.svg" with classes="w-5 h-5" %}
               <span>Import Data</span>
             </a>
 
             {% url 'export_data' as export_url %}
             <a href="{{ export_url }}"
-               class="w-full flex items-center space-x-3 px-2 py-2 rounded-md transition-colors text-left border-l-2 cursor-pointer text-sm {% if request.path == export_url %}bg-[#39404b] text-white border-indigo-500{% else %}text-gray-400 border-transparent hover:bg-[#313842] hover:text-white{% endif %}">
+               class="flex min-h-11 w-auto flex-none items-center space-x-3 rounded-md border-b-2 px-3 py-2 text-left text-sm transition-colors cursor-pointer md:w-full md:border-b-0 md:border-l-2 md:px-2 {% if request.path == export_url %}bg-[#39404b] text-white border-indigo-500{% else %}bg-[#2a2f35] text-gray-400 border-transparent hover:bg-[#313842] hover:text-white md:bg-transparent{% endif %}">
               {% include "app/icons/export.svg" with classes="w-5 h-5" %}
               <span>Export Data</span>
             </a>
 
             {% url 'advanced' as advanced_url %}
             <a href="{{ advanced_url }}"
-               class="w-full flex items-center space-x-3 px-2 py-2 rounded-md transition-colors text-left border-l-2 cursor-pointer text-sm {% if request.path == advanced_url %}bg-[#39404b] text-white border-indigo-500{% else %}text-gray-400 border-transparent hover:bg-[#313842] hover:text-white{% endif %}">
+               class="flex min-h-11 w-auto flex-none items-center space-x-3 rounded-md border-b-2 px-3 py-2 text-left text-sm transition-colors cursor-pointer md:w-full md:border-b-0 md:border-l-2 md:px-2 {% if request.path == advanced_url %}bg-[#39404b] text-white border-indigo-500{% else %}bg-[#2a2f35] text-gray-400 border-transparent hover:bg-[#313842] hover:text-white md:bg-transparent{% endif %}">
               {% include "app/icons/shield-alert.svg" with classes="w-5 h-5" %}
               <span>Advanced</span>
             </a>
 
             {% url 'about' as about_url %}
             <a href="{{ about_url }}"
-               class="w-full flex items-center space-x-3 px-2 py-2 rounded-md transition-colors text-left border-l-2 cursor-pointer text-sm {% if request.path == about_url %}bg-[#39404b] text-white border-indigo-500{% else %}text-gray-400 border-transparent hover:bg-[#313842] hover:text-white{% endif %}">
+               class="flex min-h-11 w-auto flex-none items-center space-x-3 rounded-md border-b-2 px-3 py-2 text-left text-sm transition-colors cursor-pointer md:w-full md:border-b-0 md:border-l-2 md:px-2 {% if request.path == about_url %}bg-[#39404b] text-white border-indigo-500{% else %}bg-[#2a2f35] text-gray-400 border-transparent hover:bg-[#313842] hover:text-white md:bg-transparent{% endif %}">
               {% include "app/icons/info.svg" with classes="w-5 h-5" %}
               <span>About</span>
             </a>


### PR DESCRIPTION
## Summary
- Improve the small-screen layout across the app shell, Home, media lists, settings, and calendar.
- Reduce cramped mobile spacing, make controls easier to tap, and keep media grids readable on narrow viewports.
- Make card quick actions visible and touch-sized on mobile while preserving full-card navigation to details.
- Add mobile-safe modal width constraints, a horizontal settings tab row, and a list fallback for calendar grid view on phones.

## Details
This is intended as mobile UI polish rather than a new feature. The changes focus on making existing screens more usable on phones: tighter content padding, better wrapping for filter/action rows, larger touch targets, safer modal sizing, and mobile-friendly navigation patterns.

The latest revision keeps most layout work in the existing inline Tailwind style used by the templates. The remaining CSS additions are limited to mobile grid sizing and card action behavior that depends on coarse-pointer/focus media queries.

The card interaction handling is included because the mobile action overlay needs to support both full-card navigation and the edit/list/history quick actions without relying on hover.

This branch has been rebased onto current `dev` so it no longer includes the earlier fast health check / media navigation PR changes.

## Validation
- Regenerated `src/static/css/main.css` from `src/static/css/input.css` with Tailwind CSS 4.1.4.
- `git diff --check`
- `uv run djlint src/templates --check`
- `uv run ruff check src`
- `DEBUG=False SECRET=test REDIS_URL=redis://localhost:6379 uv run python src/manage.py check`
- `DEBUG=False SECRET=test REDIS_URL=redis://localhost:6379 uv run python src/manage.py makemigrations --check --dry-run`
- `DEBUG=False SECRET=test REDIS_URL=redis://localhost:6379 SKIP=ruff-format uv run pre-commit run --all-files`

Note: `ruff-format` was skipped in the full pre-commit run because it reformats unrelated existing code outside this PR scope.