### PR TITLE
Keep paused TV and season statuses in sync

### DIFF
--- a/src/app/models.py
+++ b/src/app/models.py
@@ -992,6 +992,9 @@ class TV(Media):
             elif self.status == Status.DROPPED.value:
                 self._mark_in_progress_seasons_as_dropped()
 
+            elif self.status == Status.PAUSED.value:
+                self._mark_in_progress_seasons_as_paused()
+
             elif (
                 self.status == Status.IN_PROGRESS.value
                 and not self.seasons.filter(status=Status.IN_PROGRESS.value).exists()
@@ -1186,6 +1189,22 @@ class TV(Media):
 
         for season in in_progress_seasons:
             season.status = Status.DROPPED.value
+
+        if in_progress_seasons:
+            bulk_update_with_history(
+                in_progress_seasons,
+                Season,
+                fields=["status"],
+            )
+
+    def _mark_in_progress_seasons_as_paused(self):
+        """Mark all in-progress seasons as paused."""
+        in_progress_seasons = list(
+            self.seasons.filter(status=Status.IN_PROGRESS.value),
+        )
+
+        for season in in_progress_seasons:
+            season.status = Status.PAUSED.value
 
         if in_progress_seasons:
             bulk_update_with_history(
@@ -1433,6 +1452,17 @@ class Season(Media):
                 and self.related_tv.status != Status.DROPPED.value
             ):
                 self.related_tv.status = Status.DROPPED.value
+                bulk_update_with_history(
+                    [self.related_tv],
+                    TV,
+                    fields=["status"],
+                )
+
+            elif (
+                self.status == Status.PAUSED.value
+                and self.related_tv.status != Status.PAUSED.value
+            ):
+                self.related_tv.status = Status.PAUSED.value
                 bulk_update_with_history(
                     [self.related_tv],
                     TV,

--- a/src/app/tests/models/test_season.py
+++ b/src/app/tests/models/test_season.py
@@ -243,6 +243,14 @@ class SeasonModel(TestCase):
 
         self.assertEqual(self.season.episodes.count(), 24)
 
+    def test_paused_status_marks_tv_paused(self):
+        """Test setting status to PAUSED marks the related TV as paused."""
+        self.season.status = Status.PAUSED.value
+        self.season.save(update_fields=["status"])
+
+        self.tv.refresh_from_db()
+        self.assertEqual(self.tv.status, Status.PAUSED.value)
+
     @patch("app.models.Season.get_episode_item")
     def test_watch_method(self, mock_get_episode_item):
         """Test the watch method of the Season model."""

--- a/src/app/tests/models/test_tv.py
+++ b/src/app/tests/models/test_tv.py
@@ -358,6 +358,16 @@ class TVStatusTests(TestCase):
             1,
         )
 
+    def test_paused_status_marks_in_progress_seasons_paused(self):
+        """Test setting status to PAUSED marks in-progress seasons as paused."""
+        self.tv.status = Status.PAUSED.value
+        self.tv.save()
+
+        self.season1.refresh_from_db()
+        self.season2.refresh_from_db()
+        self.assertEqual(self.season1.status, Status.PAUSED.value)
+        self.assertEqual(self.season2.status, Status.PLANNING.value)
+
     @patch("app.models.providers.services.get_media_metadata")
     def test_in_progress_status_activates_next_season(self, mock_get_metadata):
         """Test setting status to IN_PROGRESS activates next available season."""


### PR DESCRIPTION
Closes #1539

Pausing a TV show now pauses only its in-progress seasons, leaving planned or completed seasons unchanged. Pausing an individual season also updates its parent TV, keeping the status hierarchy consistent in both directions.

Regression tests cover both transitions. The focused tests and Ruff checks pass; the broader TV/season model run has five pre-existing tests that attempt live TMDB requests and fail identically under the network-disabled test sandbox.
