### PR TITLE
fix: X button on movie track modal not working

### DIFF
--- a/src/templates/app/components/fill_track.html
+++ b/src/templates/app/components/fill_track.html
@@ -4,7 +4,9 @@
   <div class="flex items-center justify-between mb-6">
     <h2 class="text-2xl font-bold text-white line-clamp-1">{{ title }}</h2>
     <button class="text-gray-400 hover:text-white cursor-pointer"
-            @click="trackOpen = false">{% include "app/icons/x.svg" with classes="w-6 h-6" %}</button>
+            @click="trackOpen = false; createOpen = false">
+      {% include "app/icons/x.svg" with classes="w-6 h-6" %}
+    </button>
   </div>
 
   <form method="post" x-data="mediaForm" x-init="init">


### PR DESCRIPTION
## Steps

Go to the movie page.
The movie should already have been tracked. Then try to add another entry via `Add new entry`.
A modal opens.
The X button does not work. Click outside of the modal does.

## Where

I was on latest dev branch build. The demo site also has this issue. Other cases seem to work. Except games and books and possible more as such which their `Add new entry` modal also does not close but this should fix those too.

## Fix

The modal seemed to have a mismatch between `trackOpen` and `createOpen` and missing one of them.
