### PR TITLE
fix(api): return tracked episodes in season listings

### DIFF
--- a/src/api/tests/test_media_episode.py
+++ b/src/api/tests/test_media_episode.py
@@ -808,3 +808,43 @@ class MediaEpisodeTests(YamtrackApiTestCase):
         )
 
         self.assertEqual(response.status_code, 400)
+
+    @patch("api.views.services.get_media_metadata")
+    def test_season_episode_list_marks_watched_episode_as_tracked(
+        self,
+        mock_metadata,
+    ):
+        """A watched episode in a season listing should be marked as tracked."""
+        tv_item = self.items_by_type[MediaTypes.TV.value][0]
+        season_item = self.items_by_type[MediaTypes.SEASON.value][0]
+        episode_item = self.items_by_type[MediaTypes.EPISODE.value][0]
+
+        mock_metadata.return_value = self.build_episode_metadata(
+            tv_item=tv_item,
+            season_number=season_item.season_number,
+            episode_number=episode_item.episode_number,
+            title=episode_item.title,
+            image=episode_item.image,
+        )
+
+        response = self.call_api(
+            "get",
+            "api_media_season_episodes",
+            args=(
+                MediaTypes.TV.value,
+                tv_item.source,
+                tv_item.media_id,
+                season_item.season_number,
+            ),
+            params={"limit": 200},
+            headers=self.auth_headers,
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        result = response.json()["results"][0]
+        self.assertTrue(result["tracked"])
+        self.assertEqual(
+            result["consumption_id"],
+            self.episode_medias[0].id,
+        )

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -854,8 +854,12 @@ class MediaManager(models.Manager):
             params["item__season_number"] = season_number
             params["user"] = user
         elif media_type == MediaTypes.EPISODE.value:
-            params["item__season_number"] = season_number
-            params["item__episode_number"] = episode_number
+            if season_number is not None:
+                params["item__season_number"] = season_number
+
+            if episode_number is not None:
+                params["item__episode_number"] = episode_number
+
             params["related_season__user"] = user
         else:
             params["user"] = user


### PR DESCRIPTION
## Summary

Fixes season episode API responses incorrectly returning `tracked: false` for watched episodes.

## Cause

`get_season_episodes()` intentionally queries all watched episodes in a season without specifying an individual `episode_number`.

The shared media filter nevertheless added:

```python
item__episode_number=None
```
This restricted the query to episode items with a null episode number.
Episode items require an episode number, so the tracked result was always empty.

Fix

Only add season and episode-number filters when the corresponding optional argument is provided.

Exact episode lookups continue to filter by both values, while season-wide lookups can retrieve all watched episodes in that season.

Testing
Added an API regression test confirming that a watched episode is returned with tracked: true and the correct consumption_id.
Confirmed locally through the API endpoint.
Confirmed through an external API client using the season episode listing.

## AI assistance

AI assistance was used to help investigate the issue and draft the initial fix and regression test. I reviewed the changes, reproduced the bug locally, and verified the fix against both the API response and an external client.