### PR TITLE
feat(api): add episode consumption creation endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2847,6 +2847,80 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+    post:
+      tags:
+        - media
+        - history
+      summary: Create an episode watch history record
+      description: Creates another viewing of the requested episode. The request body is optional and end_date defaults to the current timezone-aware time.
+      parameters:
+        - in: path
+          name: media_type
+          required: true
+          schema:
+            $ref: "#/components/schemas/MediaTypes"
+        - in: path
+          name: source
+          required: true
+          schema:
+            $ref: "#/components/schemas/Source"
+        - in: path
+          name: media_id
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: season_number
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: episode_number
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                end_date:
+                  type: string
+                  format: date-time
+                  description: When the episode was watched. Defaults to the current time when omitted.
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConsumptionInfos"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Episode Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/v1/media/{media_type}/{source}/{media_id}/{season_number}/{episode_number}/history/{consumption_id}/:
     delete:
       tags:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2852,7 +2852,7 @@ paths:
         - media
         - history
       summary: Create an episode watch history record
-      description: Creates another viewing of the requested episode. The request body is optional and end_date defaults to the current timezone-aware time.
+      description: Creates a new consumption for the requested episode. Every successful request creates another consumption, so repeating the same request records a rewatch rather than updating an existing record. This operation is not idempotent; clients should deduplicate retries if they do not intend to record another viewing. The request body is optional and end_date defaults to the current timezone-aware time.
       parameters:
         - in: path
           name: media_type

--- a/src/api/serializers.py
+++ b/src/api/serializers.py
@@ -504,6 +504,15 @@ class HealthResponseSerializer(serializers.Serializer):
         }
 
 
+class EpisodeWatchSerializer(serializers.Serializer):
+    """Validate an optional watched-at timestamp for a new episode consumption."""
+
+    end_date = serializers.DateTimeField(
+        required=False,
+        help_text="When the episode was watched. Defaults to the current time.",
+    )
+
+
 class HistorySerializer(serializers.Serializer):
     """Serializer for watch history entries."""
 

--- a/src/api/tests/test_media_episode.py
+++ b/src/api/tests/test_media_episode.py
@@ -808,3 +808,43 @@ class MediaEpisodeTests(YamtrackApiTestCase):
         )
 
         self.assertEqual(response.status_code, 400)
+
+    @patch("api.views.services.get_media_metadata")
+    def test_season_episode_list_marks_watched_episode_as_tracked(
+        self,
+        mock_metadata,
+    ):
+        """A watched episode in a season listing should be marked as tracked."""
+        tv_item = self.items_by_type[MediaTypes.TV.value][0]
+        season_item = self.items_by_type[MediaTypes.SEASON.value][0]
+        episode_item = self.items_by_type[MediaTypes.EPISODE.value][0]
+
+        mock_metadata.return_value = self.build_episode_metadata(
+            tv_item=tv_item,
+            season_number=season_item.season_number,
+            episode_number=episode_item.episode_number,
+            title=episode_item.title,
+            image=episode_item.image,
+        )
+
+        response = self.call_api(
+            "get",
+            "api_media_season_episodes",
+            args=(
+                MediaTypes.TV.value,
+                tv_item.source,
+                tv_item.media_id,
+                season_item.season_number,
+            ),
+            params={"limit": 200},
+            headers=self.auth_headers,
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        result = response.json()["results"][0]
+        self.assertTrue(result["tracked"])
+        self.assertEqual(
+            result["consumption_id"],
+            self.episode_medias[0].id,
+        )

--- a/src/api/tests/test_media_episode.py
+++ b/src/api/tests/test_media_episode.py
@@ -1,8 +1,10 @@
 from unittest.mock import patch
 
 from django.urls import reverse
+from django.utils import timezone
+from django.utils.dateparse import parse_datetime
 
-from app.models import MediaTypes, Sources
+from app.models import TV, Episode, Item, MediaTypes, Season, Sources
 
 from .base import YamtrackApiTestCase
 from .helpers import (
@@ -15,6 +17,48 @@ from .helpers import (
 
 class MediaEpisodeTests(YamtrackApiTestCase):
     """Validate episode endpoint contracts."""
+
+    @staticmethod
+    def build_watch_metadata(
+        *,
+        media_id,
+        source=Sources.TMDB.value,
+        season_number=1,
+        episode_numbers=(1, 2, 3),
+    ):
+        """Build provider metadata used by the episode-watch workflow."""
+        episodes = [
+            {
+                "episode_number": episode_number,
+                "season_number": season_number,
+                "name": f"Episode {episode_number}",
+                "image": f"https://example.com/episode-{episode_number}.jpg",
+                "still_path": None,
+            }
+            for episode_number in episode_numbers
+        ]
+        season_metadata = {
+            "media_id": media_id,
+            "source": source,
+            "media_type": MediaTypes.SEASON.value,
+            "title": "API Test Show",
+            "season_title": f"Season {season_number}",
+            "image": "https://example.com/season.jpg",
+            "season_number": season_number,
+            "episodes": episodes,
+        }
+        return {
+            "media_id": media_id,
+            "source": source,
+            "media_type": MediaTypes.TV.value,
+            "title": "API Test Show",
+            "image": "https://example.com/tv.jpg",
+            "details": {"seasons": 1},
+            "related": {
+                "seasons": [{"season_number": season_number}],
+            },
+            f"season/{season_number}": season_metadata,
+        }
 
     def test_episode_endpoints_reject_non_tv_media_type(self):
         """Episode endpoints should return 400 when media_type is not tv."""
@@ -48,6 +92,12 @@ class MediaEpisodeTests(YamtrackApiTestCase):
                 "api_media_episode_consumption_history",
                 ("movie", "tmdb", 1, 1, 1),
                 None,
+            ),
+            (
+                "post",
+                "api_media_episode_consumption_history",
+                ("movie", "tmdb", 1, 1, 1),
+                {},
             ),
             (
                 "get",
@@ -211,6 +261,17 @@ class MediaEpisodeTests(YamtrackApiTestCase):
                     episode_item.episode_number,
                 ),
             )
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_episode_consumption_history_post_requires_authentication(self):
+        """Creating an episode consumption should require authentication."""
+        response = self.call_api(
+            "post",
+            "api_media_episode_consumption_history",
+            args=(MediaTypes.TV.value, Sources.TMDB.value, "94997", 1, 1),
+            payload={},
         )
 
         self.assertEqual(response.status_code, 403)
@@ -422,6 +483,278 @@ class MediaEpisodeTests(YamtrackApiTestCase):
         )
         for entry in payload["results"]:
             check_consumption_structure(self, entry)
+
+    @patch("app.providers.services.get_media_metadata")
+    def test_episode_consumption_history_post_creates_consumption_and_reuses_season(
+        self,
+        mock_metadata,
+    ):
+        """POST should preserve end_date and reuse the authenticated user's Season."""
+        tv_item = self.items_by_type[MediaTypes.TV.value][0]
+        season = self.season_medias[0]
+        episode_number = 2
+        supplied_end_date = "2026-07-29T17:30:00+02:00"
+        mock_metadata.return_value = self.build_watch_metadata(
+            media_id=tv_item.media_id,
+            source=tv_item.source,
+            season_number=season.item.season_number,
+        )
+        season_count = Season.objects.count()
+
+        response = self.call_api(
+            "post",
+            "api_media_episode_consumption_history",
+            args=(
+                MediaTypes.TV.value,
+                tv_item.source,
+                tv_item.media_id,
+                season.item.season_number,
+                episode_number,
+            ),
+            payload={"end_date": supplied_end_date},
+            headers=self.auth_headers,
+        )
+
+        self.assertEqual(response.status_code, 201)
+        payload = response.json()
+        self.assertIn("consumption_id", payload)
+        consumption = Episode.objects.get(pk=payload["consumption_id"])
+        self.assertEqual(consumption.related_season_id, season.id)
+        self.assertEqual(Season.objects.count(), season_count)
+        self.assertEqual(
+            consumption.end_date,
+            parse_datetime(supplied_end_date),
+        )
+        self.assertEqual(
+            parse_datetime(payload["end_date"]),
+            parse_datetime(supplied_end_date),
+        )
+
+    @patch("app.providers.services.get_media_metadata")
+    def test_episode_consumption_history_post_defaults_to_current_aware_time(
+        self,
+        mock_metadata,
+    ):
+        """Omitted end_date should use the current timezone-aware minute."""
+        tv_item = self.items_by_type[MediaTypes.TV.value][0]
+        season = self.season_medias[0]
+        mock_metadata.return_value = self.build_watch_metadata(
+            media_id=tv_item.media_id,
+            source=tv_item.source,
+            season_number=season.item.season_number,
+        )
+        expected_minute = timezone.now().replace(second=0, microsecond=0)
+
+        response = self.call_api(
+            "post",
+            "api_media_episode_consumption_history",
+            args=(
+                MediaTypes.TV.value,
+                tv_item.source,
+                tv_item.media_id,
+                season.item.season_number,
+                2,
+            ),
+            payload={},
+            headers=self.auth_headers,
+        )
+
+        self.assertEqual(response.status_code, 201)
+        watched_at = parse_datetime(response.json()["end_date"])
+        self.assertTrue(timezone.is_aware(watched_at))
+        self.assertEqual(watched_at, expected_minute)
+        self.assertEqual(watched_at.second, 0)
+        self.assertEqual(watched_at.microsecond, 0)
+
+    @patch("app.providers.services.get_media_metadata")
+    def test_episode_consumption_history_post_creates_missing_parents(
+        self,
+        mock_metadata,
+    ):
+        """POST should create source-correct TV and Season parents for the user."""
+        media_id = "94997"
+        source = Sources.MANUAL.value
+        mock_metadata.return_value = self.build_watch_metadata(
+            media_id=media_id,
+            source=source,
+        )
+
+        response = self.call_api(
+            "post",
+            "api_media_episode_consumption_history",
+            args=(MediaTypes.TV.value, source, media_id, 1, 1),
+            payload={},
+            headers=self.auth_headers,
+        )
+
+        self.assertEqual(response.status_code, 201)
+        consumption = Episode.objects.select_related(
+            "item",
+            "related_season__item",
+            "related_season__related_tv__item",
+        ).get(pk=response.json()["consumption_id"])
+        season = consumption.related_season
+        self.assertEqual(season.user, self.user1)
+        self.assertEqual(season.item.source, source)
+        self.assertEqual(season.related_tv.user, self.user1)
+        self.assertEqual(season.related_tv.item.source, source)
+        self.assertEqual(consumption.item.source, source)
+        self.assertTrue(
+            TV.objects.filter(
+                user=self.user1,
+                item__media_id=media_id,
+                item__source=source,
+            ).exists()
+        )
+
+    @patch("app.providers.services.get_media_metadata")
+    def test_episode_consumption_history_post_creates_repeat_consumptions(
+        self,
+        mock_metadata,
+    ):
+        """Every POST should create another Episode row for the same episode."""
+        tv_item = self.items_by_type[MediaTypes.TV.value][0]
+        season = self.season_medias[0]
+        mock_metadata.return_value = self.build_watch_metadata(
+            media_id=tv_item.media_id,
+            source=tv_item.source,
+            season_number=season.item.season_number,
+        )
+        args = (
+            MediaTypes.TV.value,
+            tv_item.source,
+            tv_item.media_id,
+            season.item.season_number,
+            2,
+        )
+
+        first_response = self.call_api(
+            "post",
+            "api_media_episode_consumption_history",
+            args=args,
+            payload={},
+            headers=self.auth_headers,
+        )
+        second_response = self.call_api(
+            "post",
+            "api_media_episode_consumption_history",
+            args=args,
+            payload={},
+            headers=self.auth_headers,
+        )
+
+        self.assertEqual(first_response.status_code, 201)
+        self.assertEqual(second_response.status_code, 201)
+        self.assertNotEqual(
+            first_response.json()["consumption_id"],
+            second_response.json()["consumption_id"],
+        )
+        self.assertEqual(
+            Episode.objects.filter(
+                related_season=season,
+                item__episode_number=2,
+            ).count(),
+            3,
+        )
+
+    @patch("app.providers.services.get_media_metadata")
+    def test_episode_consumption_history_post_is_scoped_to_authenticated_user(
+        self,
+        mock_metadata,
+    ):
+        """A consumption created by user1 should not be visible as user2's."""
+        media_id = "94998"
+        mock_metadata.return_value = self.build_watch_metadata(media_id=media_id)
+
+        create_response = self.call_api(
+            "post",
+            "api_media_episode_consumption_history",
+            args=(MediaTypes.TV.value, Sources.TMDB.value, media_id, 1, 1),
+            payload={},
+            headers=self.auth_headers,
+        )
+
+        self.assertEqual(create_response.status_code, 201)
+        consumption_id = create_response.json()["consumption_id"]
+        self.assertTrue(
+            Episode.objects.filter(
+                id=consumption_id,
+                related_season__user=self.user1,
+            ).exists()
+        )
+        self.assertFalse(
+            Episode.objects.filter(
+                id=consumption_id,
+                related_season__user=self.user2,
+            ).exists()
+        )
+
+        user2_response = self.call_api(
+            "get",
+            "api_media_episode_consumption_history",
+            args=(MediaTypes.TV.value, Sources.TMDB.value, media_id, 1, 1),
+            headers=self.auth_headers2,
+        )
+        self.assertEqual(user2_response.status_code, 200)
+        self.assertEqual(user2_response.json()["results"], [])
+
+    def test_episode_consumption_history_post_rejects_invalid_end_date(self):
+        """Malformed end_date should return a field-level validation error."""
+        episode_count = Episode.objects.count()
+
+        response = self.call_api(
+            "post",
+            "api_media_episode_consumption_history",
+            args=(MediaTypes.TV.value, Sources.TMDB.value, "94997", 1, 1),
+            payload={"end_date": "not-a-date"},
+            headers=self.auth_headers,
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("end_date", response.json()["errors"])
+        self.assertEqual(Episode.objects.count(), episode_count)
+
+    @patch("app.providers.services.get_media_metadata")
+    def test_episode_consumption_history_post_rejects_unknown_episode(
+        self,
+        mock_metadata,
+    ):
+        """Provider-confirmed unknown episodes should not create database rows."""
+        media_id = "94999"
+        unknown_episode_number = 999
+        mock_metadata.return_value = self.build_watch_metadata(
+            media_id=media_id,
+            episode_numbers=(1, 2, 3),
+        )
+
+        response = self.call_api(
+            "post",
+            "api_media_episode_consumption_history",
+            args=(
+                MediaTypes.TV.value,
+                Sources.TMDB.value,
+                media_id,
+                1,
+                unknown_episode_number,
+            ),
+            payload={},
+            headers=self.auth_headers,
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertFalse(
+            Item.objects.filter(
+                media_id=media_id,
+                source=Sources.TMDB.value,
+                episode_number=unknown_episode_number,
+            ).exists()
+        )
+        self.assertFalse(
+            Episode.objects.filter(
+                item__media_id=media_id,
+                item__episode_number=unknown_episode_number,
+            ).exists()
+        )
 
     def test_episode_consumption_history_invalid_media_id_returns_empty_results(self):
         """Episode history endpoint should return empty results for unknown media."""

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -5,12 +5,14 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.db import IntegrityError
-from django.utils.timezone import datetime, localdate, make_aware
+from django.utils.timezone import datetime, localdate, make_aware, now
+from drf_spectacular.utils import OpenApiResponse, extend_schema
 from health_check.views import HealthCheckView
 from rest_framework import permissions
 from rest_framework import views as drf_views
 from rest_framework.response import Response
 
+from app.episode_operations import EpisodeNotFoundError, watch_episode
 from app.forms import ManualItemForm, get_form_class
 from app.models import BasicMedia, Item, MediaTypes, Sources
 from app.providers import services, tmdb
@@ -59,6 +61,7 @@ from .serializers import (
     CompleteEpisodeSerializer,
     CompleteMediaSerializer,
     EpisodeSerializer,
+    EpisodeWatchSerializer,
     HealthResponseSerializer,
     HistorySerializer,
     InfoSerializer,
@@ -3423,6 +3426,113 @@ class MediaEpisodeConsumptionHistoryView(drf_views.APIView):
 
     serializer_class = HistorySerializer
     permission_classes = [permissions.IsAuthenticated]
+
+    @staticmethod
+    def _validate_post_path(media_type, source):
+        """Validate media type and source for episode creation."""
+        if not check_valid_type(media_type):
+            return Response(
+                {"detail": "Unsupported media type."},
+                status=HTTP.BAD_REQUEST,
+            )
+
+        if media_type != MediaTypes.TV.value:
+            return Response(
+                {
+                    "detail": "Episodes are supported only for 'tv' media type.",
+                },
+                status=HTTP.BAD_REQUEST,
+            )
+
+        if not check_source_type(media_type, source):
+            return Response(
+                {
+                    "detail": f"Cannot query `{source}` for `{media_type}` media type",
+                },
+                status=HTTP.BAD_REQUEST,
+            )
+
+        return None
+
+    @extend_schema(
+        request=EpisodeWatchSerializer,
+        responses={
+            HTTP.CREATED: HistorySerializer,
+            HTTP.BAD_REQUEST: OpenApiResponse(description="Validation error."),
+            HTTP.FORBIDDEN: OpenApiResponse(description="Authentication required."),
+            HTTP.NOT_FOUND: OpenApiResponse(description="Episode not found."),
+            HTTP.INTERNAL_SERVER_ERROR: OpenApiResponse(
+                description="Provider or server error.",
+            ),
+        },
+        description=(
+            "Create another viewing of an episode. The request body is optional; "
+            "end_date defaults to the current time."
+        ),
+        summary="Create an episode watch history record",
+    )
+    def post(
+        self,
+        request,
+        media_type,
+        source,
+        media_id,
+        season_number,
+        episode_number,
+    ):
+        """Create a new consumption for a specific episode of a TV series."""
+        path_error = self._validate_post_path(media_type, source)
+        if path_error is not None:
+            return path_error
+
+        request_serializer = EpisodeWatchSerializer(data=request.data or {})
+        if not request_serializer.is_valid():
+            return Response(
+                {
+                    "detail": HTTP.BAD_REQUEST.phrase,
+                    "errors": request_serializer.errors,
+                },
+                status=HTTP.BAD_REQUEST,
+            )
+
+        end_date = request_serializer.validated_data.get(
+            "end_date",
+            now().replace(second=0, microsecond=0),
+        )
+
+        try:
+            episode = watch_episode(
+                user=request.user,
+                media_id=media_id,
+                source=source,
+                season_number=season_number,
+                episode_number=episode_number,
+                end_date=end_date,
+            )
+        except EpisodeNotFoundError:
+            return Response(
+                {"detail": "Episode not found."},
+                status=HTTP.NOT_FOUND,
+            )
+        except services.ProviderAPIError as error:
+            if error.status_code == HTTP.NOT_FOUND:
+                return Response(
+                    {"detail": "Episode not found."},
+                    status=HTTP.NOT_FOUND,
+                )
+            return Response(
+                {
+                    "detail": "Failed to create episode consumption.",
+                    "errors": str(error),
+                },
+                status=HTTP.INTERNAL_SERVER_ERROR,
+            )
+
+        serialized = serialize_data(
+            episode,
+            serializer_class=HistorySerializer,
+        )
+        return Response(serialized, status=HTTP.CREATED)
 
     def get(self, request, media_type, source, media_id, season_number, episode_number):
         """Retrieve the history timeline for a specific episode of a tv serie."""

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -3466,8 +3466,12 @@ class MediaEpisodeConsumptionHistoryView(drf_views.APIView):
             ),
         },
         description=(
-            "Create another viewing of an episode. The request body is optional; "
-            "end_date defaults to the current time."
+            "Create a new consumption for the requested episode. Every successful "
+            "request creates another consumption, so repeating the same request "
+            "records a rewatch rather than updating an existing record. This "
+            "operation is not idempotent; clients should deduplicate retries if "
+            "they do not intend to record another viewing. The request body is "
+            "optional and end_date defaults to the current timezone-aware time."
         ),
         summary="Create an episode watch history record",
     )

--- a/src/app/episode_operations.py
+++ b/src/app/episode_operations.py
@@ -1,0 +1,80 @@
+import logging
+
+from django.conf import settings
+from django.db import transaction
+
+from app.models import Item, MediaTypes, Season, Status
+from app.providers import services
+
+logger = logging.getLogger(__name__)
+
+
+class EpisodeNotFoundError(ValueError):
+    """Raised when provider metadata does not contain the requested episode."""
+
+
+@transaction.atomic
+def watch_episode(
+    *,
+    user,
+    media_id,
+    source,
+    season_number,
+    episode_number,
+    end_date,
+):
+    """Create a watched episode and any missing user-owned parent records."""
+    season_number = int(season_number)
+    episode_number = int(episode_number)
+
+    tv_with_seasons_metadata = services.get_media_metadata(
+        "tv_with_seasons",
+        media_id,
+        source,
+        [season_number],
+    )
+    season_metadata = tv_with_seasons_metadata.get(f"season/{season_number}")
+    if not season_metadata:
+        raise EpisodeNotFoundError
+
+    episode_exists = any(
+        episode.get("episode_number") == episode_number
+        for episode in season_metadata.get("episodes", [])
+    )
+    if not episode_exists:
+        raise EpisodeNotFoundError
+
+    related_season = Season.objects.filter(
+        item__media_id=media_id,
+        item__source=source,
+        item__season_number=season_number,
+        item__episode_number=None,
+        user=user,
+    ).first()
+
+    if related_season is None:
+        item, _ = Item.objects.get_or_create(
+            media_id=media_id,
+            source=source,
+            media_type=MediaTypes.SEASON.value,
+            season_number=season_number,
+            defaults={
+                "title": tv_with_seasons_metadata["title"],
+                "image": season_metadata.get("image") or settings.IMG_NONE,
+            },
+        )
+        related_season = Season.objects.create(
+            item=item,
+            user=user,
+            score=None,
+            status=Status.IN_PROGRESS.value,
+            notes="",
+        )
+
+        logger.info("%s did not exist, it was created successfully.", related_season)
+
+    return related_season.watch(
+        episode_number,
+        end_date,
+        season_metadata=season_metadata,
+    )

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -1669,9 +1669,9 @@ class Season(Media):
         else:
             logger.info("No more episodes to watch.")
 
-    def watch(self, episode_number, end_date):
+    def watch(self, episode_number, end_date, season_metadata=None):
         """Create or add a repeat to an episode of the season."""
-        item = self.get_episode_item(episode_number)
+        item = self.get_episode_item(episode_number, season_metadata)
 
         episode = Episode.objects.create(
             related_season=self,
@@ -1682,6 +1682,7 @@ class Season(Media):
             "%s created successfully.",
             episode,
         )
+        return episode
 
     def decrease_progress(self):
         """Unwatch the current episode of the season."""
@@ -1745,7 +1746,7 @@ class Season(Media):
 
             item, _ = Item.objects.get_or_create(
                 media_id=self.item.media_id,
-                source=Sources.TMDB.value,
+                source=self.item.source,
                 media_type=MediaTypes.TV.value,
                 defaults={
                     "title": tv_metadata["title"],

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -854,8 +854,12 @@ class MediaManager(models.Manager):
             params["item__season_number"] = season_number
             params["user"] = user
         elif media_type == MediaTypes.EPISODE.value:
-            params["item__season_number"] = season_number
-            params["item__episode_number"] = episode_number
+            if season_number is not None:
+                params["item__season_number"] = season_number
+
+            if episode_number is not None:
+                params["item__episode_number"] = episode_number
+
             params["related_season__user"] = user
         else:
             params["user"] = user

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -20,6 +20,7 @@ from django.views.decorators.http import require_GET, require_http_methods, requ
 from app import config, helpers, history_processor
 from app import home as home_helpers
 from app import statistics as stats
+from app.episode_operations import watch_episode
 from app.forms import EpisodeForm, ManualItemForm, get_form_class
 from app.models import (
     TV,
@@ -706,44 +707,14 @@ def episode_save(request):
         logger.error("Form validation failed: %s", form.errors)
         return HttpResponseBadRequest("Invalid form data")
 
-    try:
-        related_season = Season.objects.get(
-            item__media_id=media_id,
-            item__source=source,
-            item__season_number=season_number,
-            item__episode_number=None,
-            user=request.user,
-        )
-    except Season.DoesNotExist:
-        tv_with_seasons_metadata = services.get_media_metadata(
-            "tv_with_seasons",
-            media_id,
-            source,
-            [season_number],
-        )
-        season_metadata = tv_with_seasons_metadata[f"season/{season_number}"]
-
-        item, _ = Item.objects.get_or_create(
-            media_id=media_id,
-            source=Sources.TMDB.value,
-            media_type=MediaTypes.SEASON.value,
-            season_number=season_number,
-            defaults={
-                "title": tv_with_seasons_metadata["title"],
-                "image": season_metadata["image"],
-            },
-        )
-        related_season = Season.objects.create(
-            item=item,
-            user=request.user,
-            score=None,
-            status=Status.IN_PROGRESS.value,
-            notes="",
-        )
-
-        logger.info("%s did not exist, it was created successfully.", related_season)
-
-    related_season.watch(episode_number, form.cleaned_data["end_date"])
+    watch_episode(
+        user=request.user,
+        media_id=media_id,
+        source=source,
+        season_number=season_number,
+        episode_number=episode_number,
+        end_date=form.cleaned_data["end_date"],
+    )
 
     return helpers.redirect_back(request)
 


### PR DESCRIPTION
## Summary

Adds API support for marking a TV episode as watched by creating a new episode consumption through the existing episode history endpoint:

```http
POST /api/v1/media/tv/{source}/{media_id}/{season_number}/{episode_number}/history/
```

The request body is optional. A supplied end_date is used as the watch time; otherwise the current time is used.

Example:
```json
{
  "end_date": "2026-07-29T17:30:00+02:00"
}
```

A successful request returns the newly created consumption using the existing history response format and HTTP 201 Created.

## Motivation

The API previously allowed clients to:

- inspect episode state;
- list episode consumption history;
- update or delete an existing consumption;

but it did not provide a supported way to create an episode consumption.

The generic media creation endpoint is not sufficient for episodes because an
episode belongs to a user-owned season and TV hierarchy and must run Yamtrack's
normal episode, season and TV progress handling.

This endpoint allows API clients to implement a complete episode watch workflow
without reproducing Yamtrack's internal parent-record logic.

## Implementation

Introduces a shared watch_episode operation that:

1. Retrieves and validates provider metadata for the requested season and
episode.
2. Rejects unknown episode numbers without creating invalid records.
3. Reuses an existing season belonging to the authenticated user.
4. Creates missing season and parent TV records when necessary.
5. Preserves the requested media source rather than assuming TMDB.
6. Creates the episode consumption through Season.watch().
7. Runs the existing Episode.save() logic that updates season and TV status.

The existing web episode-save view now uses the same shared operation, avoiding
separate implementations for the UI and API.

Season.watch() now returns the created Episode, allowing the API to
serialize the exact new consumption.

Repeated POST requests are intentionally supported. Each request represents a
new viewing and creates another episode consumption.

API behavior
Success
```http
POST /api/v1/media/tv/tmdb/94997/3/1/history/
Content-Type: application/json

{}
```
Returns:
```http
201 Created
{
  "consumption_id": 123,
  "created": "2026-07-29T15:30:02Z",
  "score": null,
  "progress": 1,
  "progressed_at": "2026-07-29T15:30:02Z",
  "status": 3,
  "start_date": "2026-07-29T15:30:02Z",
  "end_date": "2026-07-29T15:30:00Z",
  "notes": ""
}
```

## Validation
- Invalid media types or sources return 400.
- Invalid end_date values return 400.
- Unknown seasons or episodes return 404.
- Authentication remains required.
- Provider failures use the existing API error-handling conventions.

## Documentation

Updates the OpenAPI schema with:

- the optional end_date request field;
- the 201 response;
- relevant validation, authentication and not-found responses.

## Testing

Adds API coverage for:

- creating an episode consumption;
- preserving a supplied watch time;
- defaulting to the current time;
- reusing an existing season;
- creating missing season and TV parents;
- creating repeat viewings;
- user isolation;
- authentication;
- invalid media types and sources;
- invalid watch times;
- missing episodes;
- provider failures.

The endpoint was also tested from an external API client, including creation of a watch record and subsequent retrieval of the updated episode state.

## AI assistance

AI assistance was used to help draft the initial implementation and tests. I reviewed the changes, tested the endpoint locally, and verified the complete workflow through an external API client.