### PR TITLE
fix(trakt): paginate watchlist and ratings imports

### DIFF
--- a/src/integrations/imports/trakt.py
+++ b/src/integrations/imports/trakt.py
@@ -583,7 +583,10 @@ class TraktImporter:
         """Process watchlist from Trakt."""
         logger.info("Importing watchlist for user %s", self.username)
         watchlist_endpoint = f"{self.user_base_url}/watchlist"
-        watchlist_data = self._make_api_request(watchlist_endpoint)
+        watchlist_data = self._get_paginated_data(
+            watchlist_endpoint,
+            "watchlist entries",
+        )
 
         for entry in watchlist_data:
             try:
@@ -600,7 +603,7 @@ class TraktImporter:
         """Process ratings from Trakt."""
         logger.info("Importing ratings for user %s", self.username)
         ratings_endpoint = f"{self.user_base_url}/ratings"
-        ratings_data = self._make_api_request(ratings_endpoint)
+        ratings_data = self._get_paginated_data(ratings_endpoint, "ratings")
 
         for entry in ratings_data:
             try:

--- a/src/integrations/tests/imports/test_trakt.py
+++ b/src/integrations/tests/imports/test_trakt.py
@@ -122,7 +122,7 @@ class ImportTrakt(TestCase):
             "show": {"title": "Watchlist Show", "ids": {"tmdb": 54321}},
         }
 
-        mock_make_request.return_value = [watchlist_entry]
+        mock_make_request.side_effect = [[watchlist_entry], []]
         mock_get_metadata.return_value = {
             "title": "Watchlist Show",
             "image": "show_image.jpg",
@@ -130,6 +130,11 @@ class ImportTrakt(TestCase):
 
         trakt_importer = TraktImporter("testuser", self.user, "new")
         trakt_importer.process_watchlist()
+
+        calls = mock_make_request.call_args_list
+        self.assertEqual(len(calls), 2)
+        self.assertIn("?page=1&limit=1000", calls[0].args[0])  # First page
+        self.assertIn("?page=2&limit=1000", calls[1].args[0])  # Second page
 
         self.assertEqual(len(trakt_importer.bulk_media[MediaTypes.TV.value]), 1)
         tv_obj = trakt_importer.bulk_media[MediaTypes.TV.value][0]
@@ -146,7 +151,7 @@ class ImportTrakt(TestCase):
             "rating": 8,
         }
 
-        mock_make_request.return_value = [rating_entry]
+        mock_make_request.side_effect = [[rating_entry], []]
         mock_get_metadata.return_value = {
             "title": "Rated Movie",
             "image": "movie_image.jpg",
@@ -154,6 +159,11 @@ class ImportTrakt(TestCase):
 
         trakt_importer = TraktImporter("testuser", self.user, "new")
         trakt_importer.process_ratings()
+
+        calls = mock_make_request.call_args_list
+        self.assertEqual(len(calls), 2)
+        self.assertIn("?page=1&limit=1000", calls[0].args[0])  # First page
+        self.assertIn("?page=2&limit=1000", calls[1].args[0])  # Second page
 
         self.assertEqual(len(trakt_importer.bulk_media[MediaTypes.MOVIE.value]), 1)
         movie_obj = trakt_importer.bulk_media[MediaTypes.MOVIE.value][0]
@@ -214,6 +224,8 @@ class ImportTrakt(TestCase):
                     "watched_at": "2023-01-01T00:00:00.000Z",
                 },
             ],
+            [],  # Empty watchlist
+            [],  # Empty ratings
             [],  # Empty comments
         ]
 
@@ -247,6 +259,8 @@ class ImportTrakt(TestCase):
                     "watched_at": "2023-01-01T00:00:00.000Z",
                 },
             ],
+            [],  # Empty watchlist
+            [],  # Empty ratings
             [],  # Empty comments
         ]
 


### PR DESCRIPTION
Closes #1511

`process_watchlist` and `process_ratings` called `_make_api_request` directly, so Trakt returned only the first page and everything past it was silently dropped — a ~1000-item watchlist imported as 100. `process_history` and `process_comments` already go through `_get_paginated_data`; this routes the other two through it too.

The existing watchlist/ratings tests now assert the paged request URLs, matching `test_process_comments`; they fail on `dev` and pass with the fix.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
