### PR TITLE
fix: resolve Plex TV episodes from a TMDB-only episode GUID

### DIFF
--- a/src/integrations/tests/test_webhooks_plex.py
+++ b/src/integrations/tests/test_webhooks_plex.py
@@ -87,6 +87,102 @@ class PlexWebhookTests(TestCase):
         )
         self.assertIsNotNone(episode.end_date)
 
+    def test_tv_episode_tmdb_only_guid_mark_played(self):
+        """Test webhook handles a TV episode with only a TMDB episode GUID.
+
+        Plex's tv.plex.agents.series agent frequently matches an episode
+        against TMDB without a TVDB or IMDB cross-reference, leaving a single
+        episode-level ``tmdb://`` GUID.
+        """
+        payload = {
+            "event": "media.scrobble",
+            "Account": {
+                "title": "testuser",
+            },
+            "Metadata": {
+                "type": "episode",
+                "grandparentTitle": "Below Deck Mediterranean",
+                "index": 14,
+                "parentIndex": 2,
+                "Guid": [
+                    {
+                        # TMDB episode ID for S02E14, "Con-Text is Everything"
+                        "id": "tmdb://1347510",
+                    },
+                ],
+            },
+        }
+
+        data = {
+            "payload": json.dumps(payload),
+        }
+
+        response = self.client.post(
+            self.url,
+            data=data,
+            format="multipart",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        tv_item = Item.objects.get(media_type=MediaTypes.TV.value, media_id="66902")
+        self.assertEqual(tv_item.title, "Below Deck Mediterranean")
+
+        tv = TV.objects.get(item=tv_item, user=self.user)
+        self.assertEqual(tv.status, Status.IN_PROGRESS.value)
+
+        season = Season.objects.get(
+            item__media_id="66902",
+            item__season_number=2,
+        )
+        self.assertEqual(season.status, Status.IN_PROGRESS.value)
+
+        episode = Episode.objects.get(
+            item__media_id="66902",
+            item__season_number=2,
+            item__episode_number=14,
+        )
+        self.assertIsNotNone(episode.end_date)
+
+    def test_tv_episode_tmdb_only_guid_wrong_show_not_tracked(self):
+        """Test a TMDB-only episode GUID that no search candidate confirms.
+
+        The episode ID must round-trip against the season metadata of a show
+        found by title, otherwise nothing is tracked.
+        """
+        payload = {
+            "event": "media.scrobble",
+            "Account": {
+                "title": "testuser",
+            },
+            "Metadata": {
+                "type": "episode",
+                "grandparentTitle": "Below Deck Mediterranean",
+                "index": 14,
+                "parentIndex": 2,
+                "Guid": [
+                    {
+                        # Not an episode ID belonging to this show
+                        "id": "tmdb://999999999",
+                    },
+                ],
+            },
+        }
+
+        data = {
+            "payload": json.dumps(payload),
+        }
+
+        response = self.client.post(
+            self.url,
+            data=data,
+            format="multipart",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Episode.objects.count(), 0)
+        self.assertEqual(TV.objects.count(), 0)
+
     def test_movie_mark_played(self):
         """Test webhook handles movie mark played event."""
         payload = {

--- a/src/integrations/webhooks/base.py
+++ b/src/integrations/webhooks/base.py
@@ -50,6 +50,19 @@ class BaseWebhookProcessor(TVWebhookMixin, MovieWebhookMixin, AnimeWebhookMixin)
         """Get episode number from payload."""
         raise NotImplementedError
 
+    def _get_show_title(self, _payload):
+        """Get the parent show title from payload.
+
+        Optional. Processors that cannot supply it fall back to None, which
+        disables TMDB episode ID resolution for that source.
+        """
+
+    def _get_season_number(self, _payload):
+        """Get the season number from payload.
+
+        Optional, see _get_show_title.
+        """
+
     def _process_media(self, payload, user, ids):
         """Route processing based on media type."""
         media_type = self._get_media_type(payload)

--- a/src/integrations/webhooks/plex.py
+++ b/src/integrations/webhooks/plex.py
@@ -90,6 +90,12 @@ class PlexWebhookProcessor(BaseWebhookProcessor):
     def _get_episode_number(self, payload):
         return payload["Metadata"].get("index")
 
+    def _get_show_title(self, payload):
+        return payload["Metadata"].get("grandparentTitle")
+
+    def _get_season_number(self, payload):
+        return payload["Metadata"].get("parentIndex")
+
     def _extract_external_ids(self, payload):
         guids = payload["Metadata"].get("Guid", [])
         guid = payload["Metadata"].get("guid", None)

--- a/src/integrations/webhooks/tv.py
+++ b/src/integrations/webhooks/tv.py
@@ -1,14 +1,19 @@
 import logging
 
+import requests
 from django.utils import timezone
 
 import app
 from app.models import MediaTypes, Sources, Status
 from app.providers import tvdb as tvdb_provider
+from app.providers.services import ProviderAPIError
 
 from . import anime_mappings
 
 logger = logging.getLogger(__name__)
+
+# How many TMDB title-search candidates to confirm an episode ID against.
+TMDB_SEARCH_CANDIDATES = 5
 
 
 class TVWebhookMixin:
@@ -16,44 +21,12 @@ class TVWebhookMixin:
 
     def _process_tv(self, payload, user, ids):
         anidb_id = ids.get("anidb_id")
-        if user.anime_enabled and anidb_id:
-            mapping_data = anime_mappings.fetch_mapping_data()
-            episode_number = self._get_episode_number(payload)
-            mal_id = None
-            mal_episode_number = None
-
-            if not episode_number:
-                logger.warning(
-                    "No episode number found for AniDB ID: %s",
-                    anidb_id,
-                )
-            else:
-                mal_id, mal_episode_number = anime_mappings.get_mal_id_from_anidb(
-                    mapping_data,
-                    anidb_id,
-                    episode_number,
-                )
-
-            if episode_number and not mal_id:
-                logger.info(
-                    "AniDB ID %s not found in mapping, "
-                    "falling through to TV processing",
-                    anidb_id,
-                )
-            elif episode_number:
-                logger.info(
-                    "Detected anime via AniDB ID: %s. Matching MAL ID: %s, Episode: %d",
-                    anidb_id,
-                    mal_id,
-                    mal_episode_number,
-                )
-                self._handle_anime(
-                    mal_id,
-                    mal_episode_number,
-                    payload,
-                    user,
-                )
-                return
+        if (
+            user.anime_enabled
+            and anidb_id
+            and self._process_anidb_episode(anidb_id, payload, user)
+        ):
+            return
 
         tvdb_episode_id = ids.get("tvdb_id")
         if tvdb_episode_id:
@@ -74,10 +47,129 @@ class TVWebhookMixin:
         if imdb_id and self._process_imdb_episode(imdb_id, payload, user):
             return
 
+        tmdb_episode_id = ids.get("tmdb_id")
+        if tmdb_episode_id and self._process_tmdb_episode(
+            tmdb_episode_id, payload, user
+        ):
+            return
+
         if imdb_id:
             logger.warning("No matching TMDB ID found for IMDB ID: %s", imdb_id)
+        elif tmdb_episode_id:
+            logger.warning(
+                "Could not resolve TMDB episode ID %s to a show",
+                tmdb_episode_id,
+            )
         else:
             logger.warning("No TVDB or IMDB ID found for TV episode")
+
+    def _process_anidb_episode(self, anidb_id, payload, user):
+        """Process an anime episode using an AniDB ID.
+
+        Returns True when the episode was handled as anime, False to fall
+        through to regular TV processing.
+        """
+        episode_number = self._get_episode_number(payload)
+        if not episode_number:
+            logger.warning("No episode number found for AniDB ID: %s", anidb_id)
+            return False
+
+        mapping_data = anime_mappings.fetch_mapping_data()
+        mal_id, mal_episode_number = anime_mappings.get_mal_id_from_anidb(
+            mapping_data,
+            anidb_id,
+            episode_number,
+        )
+
+        if not mal_id:
+            logger.info(
+                "AniDB ID %s not found in mapping, falling through to TV processing",
+                anidb_id,
+            )
+            return False
+
+        logger.info(
+            "Detected anime via AniDB ID: %s. Matching MAL ID: %s, Episode: %d",
+            anidb_id,
+            mal_id,
+            mal_episode_number,
+        )
+        self._handle_anime(mal_id, mal_episode_number, payload, user)
+        return True
+
+    def _process_tmdb_episode(self, tmdb_episode_id, payload, user):
+        """Process a TV episode from an episode-level TMDB ID.
+
+        Plex's tv.plex.agents.series agent regularly matches an episode
+        against TMDB with no TVDB or IMDB cross-reference, leaving a lone
+        episode-level ``tmdb://`` GUID. TMDB exposes no endpoint that maps an
+        episode ID back to its show, so search by the show title carried in
+        the payload and accept a candidate only when the episode ID
+        round-trips against that candidate's season metadata. The ID match is
+        what makes the title search safe.
+        """
+        show_title = self._get_show_title(payload)
+        season_number = self._get_season_number(payload)
+        if not show_title or season_number is None:
+            logger.debug(
+                "Cannot resolve TMDB episode ID %s without a show title and "
+                "season number",
+                tmdb_episode_id,
+            )
+            return False
+
+        try:
+            search_results = app.providers.tmdb.search(
+                MediaTypes.TV.value,
+                show_title,
+                1,
+            )["results"]
+        except (ProviderAPIError, requests.exceptions.RequestException):
+            logger.exception("TMDB search failed for show title: %s", show_title)
+            return False
+
+        for candidate in search_results[:TMDB_SEARCH_CANDIDATES]:
+            media_id = candidate["media_id"]
+            try:
+                tv_metadata = app.providers.tmdb.tv_with_seasons(
+                    media_id,
+                    [season_number],
+                )
+            except (ProviderAPIError, requests.exceptions.RequestException, KeyError):
+                logger.debug(
+                    "Could not fetch season %s of TMDB show %s",
+                    season_number,
+                    media_id,
+                )
+                continue
+
+            season_metadata = tv_metadata.get(f"season/{season_number}")
+            if not season_metadata:
+                continue
+
+            for episode in season_metadata.get("episodes", []):
+                if str(episode.get("id")) != str(tmdb_episode_id):
+                    continue
+
+                episode_number = episode["episode_number"]
+                logger.info(
+                    "Detected TV episode via TMDB episode ID: %s, "
+                    "TMDB ID: %s, Season: %d, Episode: %d",
+                    tmdb_episode_id,
+                    media_id,
+                    season_number,
+                    episode_number,
+                )
+                self._handle_tv_episode(
+                    media_id,
+                    season_number,
+                    episode_number,
+                    payload,
+                    user,
+                )
+                return True
+
+        return False
 
     def _process_tvdb_episode(self, tvdb_episode, tvdb_episode_id, payload, user):
         """Process a TV episode using TVDB metadata."""


### PR DESCRIPTION
Supersedes #1109 (rebased onto current `dev`, with tests). Refs #1071, and the same class of problem discussed in #1550.

## Problem

Plex's `tv.plex.agents.series` agent frequently matches an episode against TMDB **without** a TVDB or IMDB cross-reference, leaving a lone episode-level `tmdb://` GUID. `_process_tv` resolves `anidb -> tvdb -> imdb` only, so the `tmdb_id` that `_extract_external_ids` already returns is discarded and the scrobble is dropped:

```
[INFO]    Extracted IDs from payload: {'tmdb_id': '1347510', 'imdb_id': None, 'tvdb_id': None, 'anidb_id': None}
[INFO]    Received webhook for tv: Below Deck Mediterranean S02E14
[WARNING] No TVDB or IMDB ID found for TV episode
```

This is **per-episode, not per-library**, which is why it reads as "randomly fails" (#1071). Same show, same library, same agent:

| Episode | Plex `Guid` | Result |
|---|---|---|
| S02E06 | `imdb://tt6978246`, `tmdb://1322600`, `tvdb://6113033` | tracked |
| S02E08 | `imdb://tt7093454`, `tmdb://1330649`, `tvdb://6127613` | tracked |
| S02E12 | `tmdb://1336946` | **dropped** |
| S02E14 | `tmdb://1347510` | **dropped** |

The show-level GUIDs are complete; TMDB simply has no episode-level external IDs for those episodes, so re-matching in Plex does not help.

Over one deployment's history this lost **66 of 84** TV webhooks (79%). Movies were unaffected (24/24) because the Plex movie agent supplies all three GUIDs. The webhook returns HTTP 200 throughout, so nothing external shows a fault.

## Approach

TMDB exposes no endpoint that maps an episode ID back to its show. `_process_tmdb_episode` therefore searches by the show title from the payload, then accepts a candidate **only when the episode ID round-trips** against that candidate's season metadata:

```python
for episode in season_metadata.get("episodes", []):
    if str(episode.get("id")) != str(tmdb_episode_id):
        continue
    ...
```

The ID match is what makes the title search safe — a bare title search would be a guess. The episode number is then taken from TMDB rather than the payload index. It runs last, after `tvdb` and `imdb`, so no existing resolution path changes behaviour.

This is the same idea as @Floydian-dk's #1109; that PR was written against the older layout where `_process_tv` still lived in `base.py`, so it no longer applies. Differences here: reads `season_metadata["episodes"]` directly instead of changing the shape of `tmdb.episode()`'s return dict, bounds the search to the first 5 candidates, catches `ProviderAPIError`/`RequestException` rather than bare `Exception`, and adds tests.

## Changes

- `webhooks/tv.py` — `_process_tmdb_episode()`. Also extracts the AniDB branch into `_process_anidb_episode()` so `_process_tv` stays within the project's own `C901`/`PLR0912` limits.
- `webhooks/base.py` — `_get_show_title()` / `_get_season_number()` hooks defaulting to `None`, so Jellyfin and Emby are unchanged until they implement them.
- `webhooks/plex.py` — those two hooks, reading `grandparentTitle` / `parentIndex`.
- `tests/test_webhooks_plex.py` — a TMDB-only GUID that should track, and one whose episode ID matches no candidate and should track nothing.

## Verification

`pytest test_webhooks_plex.py test_webhooks_jellyfin.py test_webhooks_emby.py` — **52 passed**. `ruff check src/integrations/` clean.

Running live, the payload that previously dropped now resolves:

```
[INFO] Detected TV episode via TMDB episode ID: 1347510, TMDB ID: 66902, Season: 2, Episode: 14
[INFO] Marked episode as played: Below Deck Mediterranean S02E14
```

## Not addressed

Episodes whose Plex season number does not exist on TMDB (Plex numbers Shark Week by year, `S2026`) still fail with `Season N not found in The Movie Database`. That is a separate problem.
