### PR TITLE
fix: sort calendar events by title/season/episode as tiebreaker

### DIFF
--- a/src/events/models.py
+++ b/src/events/models.py
@@ -213,7 +213,14 @@ class EventManager(models.Manager):
                 default=Value(0),
                 output_field=IntegerField(),
             ),
-        ).order_by("datetime__date", "is_sentinel", "datetime")
+        ).order_by(
+            "datetime__date",
+            "is_sentinel",
+            "datetime",
+            "item__title",
+            "item__season_number",
+            "content_number",
+        )
 
 
 class Event(models.Model):


### PR DESCRIPTION
On the calendar page, TV show episodes that are released at the exact same datetime show up in an inconsistent order - especially noticeable when multiple episodes are released at once.

Add some extra fields as tiebreaker:
- `item__title` (show name)
- `item__season_number` (season number)
- `content_number` (episode number)
