### PR TITLE
Fix anime not getting new episode release date

### DIFF
--- a/src/events/calendar/selectors.py
+++ b/src/events/calendar/selectors.py
@@ -70,17 +70,28 @@ def filter_items_to_fetch(items):
     tv_q = Q(id__in=tv_items_to_include)
     movie_q = Q(id__in=movie_items_to_include)
 
+    anime_q = Q(
+        media_type=MediaTypes.ANIME.value,
+        source=Sources.MAL.value,
+    )
+
     comic_q = Q(media_type=MediaTypes.COMIC.value) & (
         Q(event__isnull=True) | Q(latest_comic_event_datetime__gte=one_year_ago)
     )
 
     other_q = (
-        ~Q(media_type__in=[MediaTypes.TV.value, MediaTypes.COMIC.value])
+        ~Q(
+            media_type__in=[
+                MediaTypes.TV.value,
+                MediaTypes.ANIME.value,
+                MediaTypes.COMIC.value,
+            ],
+        )
         & ~Q(media_type=MediaTypes.MOVIE.value, source=Sources.TMDB.value)
         & (Q(event__isnull=True) | Q(has_future_events=True))
     )
 
-    return annotated.filter(tv_q | movie_q | comic_q | other_q).distinct()
+    return annotated.filter(tv_q | movie_q | anime_q | comic_q | other_q).distinct()
 
 
 def get_tv_items_to_include(tv_items):

--- a/src/events/tests/calendar/test_selectors.py
+++ b/src/events/tests/calendar/test_selectors.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 
 from app.models import TV, Anime, Item, MediaTypes, Sources, Status
 from app.providers import services
+from events.calendar.main import fetch_releases
 from events.calendar.selectors import (
     get_changed_tmdb_movie_ids,
     get_changed_tmdb_tv_ids,
@@ -17,6 +18,77 @@ from events.tests.calendar.utils import CalendarFixturesMixin
 
 class CalendarSelectorTests(CalendarFixturesMixin, TestCase):
     """Test calendar item selection rules."""
+
+    @patch("events.calendar.selectors.tmdb.movie_changes")
+    @patch("events.calendar.selectors.tmdb.tv_changes")
+    @patch("events.calendar.anime.services.api_request")
+    def test_past_only_anime_is_refreshed_and_saves_future_episode(
+        self,
+        mock_api_request,
+        mock_tv_changes,
+        mock_movie_changes,
+    ):
+        """Stale anime events must not prevent AniList schedule refreshes."""
+        mock_tv_changes.return_value = set()
+        mock_movie_changes.return_value = set()
+        Event.objects.create(
+            item=self.anime_item,
+            content_number=17,
+            datetime=timezone.now() - timezone.timedelta(days=1),
+        )
+        future_datetime = (timezone.now() + timezone.timedelta(days=7)).replace(
+            microsecond=0,
+        )
+        future_timestamp = int(future_datetime.timestamp())
+        mock_api_request.return_value = {
+            "data": {
+                "Page": {
+                    "pageInfo": {"hasNextPage": False},
+                    "media": [
+                        {
+                            "idMal": int(self.anime_item.media_id),
+                            "endDate": {"year": None, "month": None, "day": None},
+                            "episodes": 18,
+                            "airingSchedule": {
+                                "nodes": [
+                                    {"episode": 18, "airingAt": future_timestamp},
+                                ],
+                            },
+                        },
+                    ],
+                },
+            },
+        }
+
+        items = get_items_to_process(self.user)
+
+        self.assertIn(self.anime_item, items)
+        fetch_releases(items_to_process=[self.anime_item])
+
+        mock_api_request.assert_called_once()
+        saved_event = Event.objects.get(item=self.anime_item, content_number=18)
+        self.assertEqual(saved_event.datetime, future_datetime)
+        self.assertGreater(saved_event.datetime, timezone.now())
+
+    @patch("events.calendar.selectors.tmdb.movie_changes")
+    @patch("events.calendar.selectors.tmdb.tv_changes")
+    def test_anime_with_future_event_continues_to_be_selected(
+        self,
+        mock_tv_changes,
+        mock_movie_changes,
+    ):
+        """Existing future anime events remain eligible for schedule refreshes."""
+        mock_tv_changes.return_value = set()
+        mock_movie_changes.return_value = set()
+        Event.objects.create(
+            item=self.anime_item,
+            content_number=17,
+            datetime=timezone.now() + timezone.timedelta(days=1),
+        )
+
+        items = get_items_to_process(self.user)
+
+        self.assertIn(self.anime_item, items)
 
     @patch("events.calendar.selectors.tmdb.movie_changes")
     @patch("events.calendar.selectors.tmdb.tv_changes")


### PR DESCRIPTION
Found a bug where some animes were not getting newly announced future episodes. I attempted a fix by checking the AniList every time. Not sure if this is a good fix / correct fix, however it seems to work locally 