### PR TITLE
feat(webhooks): use the payload TMDB ID for TV episodes

### DIFF
--- a/src/integrations/tests/test_webhooks_jellyfin.py
+++ b/src/integrations/tests/test_webhooks_jellyfin.py
@@ -263,6 +263,82 @@ class JellyfinWebhookTests(TestCase):
             self.user,
         )
 
+    @patch("integrations.webhooks.base.BaseWebhookProcessor._handle_tv_episode")
+    def test_tv_episode_uses_tmdb_when_no_episode_level_id(
+        self,
+        mock_handle_tv_episode,
+    ):
+        """Test the show's TMDB ID is used when no episode-level ID is sent."""
+        self.user.anime_enabled = False
+        self.user.save(update_fields=["anime_enabled"])
+        payload = {
+            "Event": "Stop",
+            "Item": {
+                "Type": "Episode",
+                "Name": "Episode",
+                "ProviderIds": {"Tmdb": "1396"},
+                "SeriesName": "Breaking Bad",
+                "ParentIndexNumber": 1,
+                "IndexNumber": 3,
+                "UserData": {"Played": True},
+            },
+        }
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        mock_handle_tv_episode.assert_called_once_with(
+            "1396",
+            1,
+            3,
+            payload,
+            self.user,
+        )
+
+    @patch("integrations.webhooks.base.BaseWebhookProcessor._handle_tv_episode")
+    @patch("app.providers.tmdb.find")
+    def test_tv_episode_falls_back_to_tmdb_when_imdb_lookup_misses(
+        self,
+        mock_tmdb_find,
+        mock_handle_tv_episode,
+    ):
+        """Test the payload TMDB ID is used after an IMDB lookup finds nothing."""
+        self.user.anime_enabled = False
+        self.user.save(update_fields=["anime_enabled"])
+        mock_tmdb_find.return_value = {"tv_episode_results": []}
+        payload = {
+            "Event": "Stop",
+            "Item": {
+                "Type": "Episode",
+                "Name": "Episode",
+                "ProviderIds": {"Tmdb": "1396", "Imdb": "tt0903747"},
+                "SeriesName": "Breaking Bad",
+                "ParentIndexNumber": 1,
+                "IndexNumber": 3,
+                "UserData": {"Played": True},
+            },
+        }
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        mock_tmdb_find.assert_any_call("tt0903747", "imdb_id")
+        mock_handle_tv_episode.assert_called_once_with(
+            "1396",
+            1,
+            3,
+            payload,
+            self.user,
+        )
+
     def test_mark_played_ignored_when_disabled(self):
         """Test Jellyfin MarkPlayed events are ignored by default."""
         payload = {

--- a/src/integrations/webhooks/base.py
+++ b/src/integrations/webhooks/base.py
@@ -50,6 +50,10 @@ class BaseWebhookProcessor(TVWebhookMixin, MovieWebhookMixin, AnimeWebhookMixin)
         """Get episode number from payload."""
         raise NotImplementedError
 
+    def _get_season_number(self, payload):
+        """Get season number from payload."""
+        raise NotImplementedError
+
     def _process_media(self, payload, user, ids):
         """Route processing based on media type."""
         media_type = self._get_media_type(payload)

--- a/src/integrations/webhooks/emby.py
+++ b/src/integrations/webhooks/emby.py
@@ -70,6 +70,9 @@ class EmbyWebhookProcessor(BaseWebhookProcessor):
     def _get_episode_number(self, payload):
         return payload["Item"].get("IndexNumber")
 
+    def _get_season_number(self, payload):
+        return payload["Item"].get("ParentIndexNumber")
+
     def _extract_external_ids(self, payload):
         provider_ids = payload["Item"].get("ProviderIds", {})
         return {

--- a/src/integrations/webhooks/jellyfin.py
+++ b/src/integrations/webhooks/jellyfin.py
@@ -93,6 +93,9 @@ class JellyfinWebhookProcessor(BaseWebhookProcessor):
     def _get_episode_number(self, payload):
         return payload["Item"].get("IndexNumber")
 
+    def _get_season_number(self, payload):
+        return payload["Item"].get("ParentIndexNumber")
+
     def _extract_external_ids(self, payload):
         provider_ids = payload["Item"].get("ProviderIds", {})
         return {

--- a/src/integrations/webhooks/plex.py
+++ b/src/integrations/webhooks/plex.py
@@ -90,6 +90,9 @@ class PlexWebhookProcessor(BaseWebhookProcessor):
     def _get_episode_number(self, payload):
         return payload["Metadata"].get("index")
 
+    def _get_season_number(self, payload):
+        return payload["Metadata"].get("parentIndex")
+
     def _extract_external_ids(self, payload):
         guids = payload["Metadata"].get("Guid", [])
         guid = payload["Metadata"].get("guid", None)

--- a/src/integrations/webhooks/tv.py
+++ b/src/integrations/webhooks/tv.py
@@ -42,10 +42,40 @@ class TVWebhookMixin:
         if imdb_id and self._process_imdb_episode(imdb_id, payload, user):
             return
 
+        tmdb_id = ids.get("tmdb_id")
+        if tmdb_id and self._process_tmdb_episode(tmdb_id, payload, user):
+            return
+
         if imdb_id:
             logger.warning("No matching TMDB ID found for IMDB ID: %s", imdb_id)
         else:
-            logger.warning("No TVDB or IMDB ID found for TV episode")
+            logger.warning("No TVDB, IMDB or TMDB ID found for TV episode")
+
+    def _process_tmdb_episode(self, tmdb_id, payload, user):
+        """Process a TV episode using the show's TMDB ID.
+
+        The TVDB and IMDB routes both resolve an episode-level identifier. A
+        source that only knows the show's TMDB ID has to supply the season and
+        episode numbers itself, which the payload already carries.
+        """
+        season_number = self._get_season_number(payload)
+        episode_number = self._get_episode_number(payload)
+
+        if season_number is None or episode_number is None:
+            logger.debug(
+                "TMDB ID %s found but the payload has no season or episode number",
+                tmdb_id,
+            )
+            return False
+
+        logger.info(
+            "Detected TV episode via payload TMDB ID: %s, Season: %d, Episode: %d",
+            tmdb_id,
+            season_number,
+            episode_number,
+        )
+        self._handle_tv_episode(tmdb_id, season_number, episode_number, payload, user)
+        return True
 
     def _process_anidb_episode(self, anidb_id, payload, user):
         """Process an anime episode using its AniDB ID.

--- a/src/integrations/webhooks/tv.py
+++ b/src/integrations/webhooks/tv.py
@@ -16,44 +16,12 @@ class TVWebhookMixin:
 
     def _process_tv(self, payload, user, ids):
         anidb_id = ids.get("anidb_id")
-        if user.anime_enabled and anidb_id:
-            mapping_data = anime_mappings.fetch_mapping_data()
-            episode_number = self._get_episode_number(payload)
-            mal_id = None
-            mal_episode_number = None
-
-            if not episode_number:
-                logger.warning(
-                    "No episode number found for AniDB ID: %s",
-                    anidb_id,
-                )
-            else:
-                mal_id, mal_episode_number = anime_mappings.get_mal_id_from_anidb(
-                    mapping_data,
-                    anidb_id,
-                    episode_number,
-                )
-
-            if episode_number and not mal_id:
-                logger.info(
-                    "AniDB ID %s not found in mapping, "
-                    "falling through to TV processing",
-                    anidb_id,
-                )
-            elif episode_number:
-                logger.info(
-                    "Detected anime via AniDB ID: %s. Matching MAL ID: %s, Episode: %d",
-                    anidb_id,
-                    mal_id,
-                    mal_episode_number,
-                )
-                self._handle_anime(
-                    mal_id,
-                    mal_episode_number,
-                    payload,
-                    user,
-                )
-                return
+        if (
+            user.anime_enabled
+            and anidb_id
+            and self._process_anidb_episode(anidb_id, payload, user)
+        ):
+            return
 
         tvdb_episode_id = ids.get("tvdb_id")
         if tvdb_episode_id:
@@ -78,6 +46,44 @@ class TVWebhookMixin:
             logger.warning("No matching TMDB ID found for IMDB ID: %s", imdb_id)
         else:
             logger.warning("No TVDB or IMDB ID found for TV episode")
+
+    def _process_anidb_episode(self, anidb_id, payload, user):
+        """Process an anime episode using its AniDB ID.
+
+        Returns False when the episode cannot be mapped, so the caller falls
+        through to the regular TV routes.
+        """
+        episode_number = self._get_episode_number(payload)
+        if not episode_number:
+            logger.warning(
+                "No episode number found for AniDB ID: %s",
+                anidb_id,
+            )
+            return False
+
+        mapping_data = anime_mappings.fetch_mapping_data()
+        mal_id, mal_episode_number = anime_mappings.get_mal_id_from_anidb(
+            mapping_data,
+            anidb_id,
+            episode_number,
+        )
+
+        if not mal_id:
+            logger.info(
+                "AniDB ID %s not found in mapping, falling through to TV processing",
+                anidb_id,
+            )
+            return False
+
+        logger.info(
+            "Detected anime via AniDB ID: %s. Matching MAL ID: %s, Episode: %d",
+            anidb_id,
+            mal_id,
+            mal_episode_number,
+        )
+        self._handle_anime(mal_id, mal_episode_number, payload, user)
+        return True
+
 
     def _process_tvdb_episode(self, tvdb_episode, tvdb_episode_id, payload, user):
         """Process a TV episode using TVDB metadata."""


### PR DESCRIPTION
### Problem

`_process_tv` resolves an episode through AniDB, TVDB, then IMDB. All three need an *episode-level* identifier. A payload that carries only the show's TMDB ID plus `ParentIndexNumber` and `IndexNumber` is dropped with `No TVDB or IMDB ID found for TV episode`, even though `_extract_external_ids` already pulled `tmdb_id` out and the season and episode numbers are sitting in the payload.

The movie handler doesn't have this gap — it treats the payload TMDB ID as its primary route and logs `Detected movie via TMDB ID`. This brings TV into line.

It also affects the IMDB route in practice: a source sending the *series* IMDB ID rather than the episode's lands in `tv_results` instead of `tv_episode_results`, so `_find_tv_media_id` returns nothing and the event is dropped despite TMDB, season and episode all being present.

### Changes

Two commits, separated so the refactor can be reviewed independently.

**1. `refactor(webhooks): extract the AniDB route from _process_tv`**

The AniDB path was inlined while TVDB and IMDB were already separate methods. Extracting it to `_process_anidb_episode` makes the routes consistent and keeps `_process_tv` within ruff's complexity limits once a fourth route is added. No behaviour change — the only difference is that `fetch_mapping_data()` now runs after the episode-number check rather than before it, avoiding a lookup whose result was discarded.

**2. `feat(webhooks): use the payload TMDB ID for TV episodes`**

Adds `_process_tmdb_episode`, placed *after* the existing routes so it is only reached once they have failed. Any payload that works today takes exactly the same path it did before. Also adds `_get_season_number` to the three processors, which each already read the season number inline for logging but never exposed it.

### Testing

Two tests added to `test_webhooks_jellyfin.py`: one for a TMDB-only payload, one where the IMDB lookup misses and TMDB picks it up. All 52 tests across the Jellyfin, Plex and Emby suites pass, and `ruff check` is clean.

Also verified end to end against a running instance. A payload with `{"Tmdb": "1405"}` and no IMDB ID created the show, seasons and episode correctly, and a payload carrying a series-level IMDB ID alongside TMDB fell through to the new route and tracked as expected.

### Motivation

I'm looking at Stremio as a webhook source. Stremio identifies episodes as `tt0903747:1:3` — series IMDB ID plus season and episode — so it can satisfy none of the three existing routes despite holding everything needed to identify the episode.