### PR TITLE
feat: change tv season statuses when show status is changed

### DIFF
--- a/src/app/models.py
+++ b/src/app/models.py
@@ -983,6 +983,10 @@ class TV(Media):
     @tracker  # postpone field reset until after the save
     def save(self, *args, **kwargs):
         """Save the media instance."""
+        # Read before saving, the seasons of a show update it in bulk to avoid
+        # cascading back, which leaves the tracker holding an outdated status
+        previous_status = self._get_stored_status()
+
         super(Media, self).save(*args, **kwargs)
 
         if self.tracker.has_changed("status"):
@@ -990,7 +994,7 @@ class TV(Media):
                 self._completed()
 
             elif self.status == Status.DROPPED.value:
-                self._mark_in_progress_seasons_as_dropped()
+                self._drop_started_seasons()
 
             elif (
                 self.status == Status.IN_PROGRESS.value
@@ -998,7 +1002,17 @@ class TV(Media):
             ):
                 self._start_next_available_season()
 
+            elif previous_status and previous_status != self.status:
+                self._move_seasons_from_status(previous_status, self.status)
+
             self.item.fetch_releases(delay=True)
+
+    def _get_stored_status(self):
+        """Return the status currently stored for the show, if any."""
+        if not self.pk:
+            return None
+
+        return TV.objects.filter(pk=self.pk).values_list("status", flat=True).first()
 
     @property
     def progress(self):
@@ -1178,18 +1192,42 @@ class TV(Media):
                 level=UserMessageLevel.WARNING,
             )
 
-    def _mark_in_progress_seasons_as_dropped(self):
-        """Mark all in-progress seasons as dropped."""
-        in_progress_seasons = list(
-            self.seasons.filter(status=Status.IN_PROGRESS.value),
+    def _drop_started_seasons(self):
+        """Drop every season that was started but never finished.
+
+        Dropping a show abandons everything still underway, so paused seasons
+        follow along with the in-progress ones. Seasons never started stay
+        planned and finished seasons stay completed.
+        """
+        self._move_seasons(
+            self.seasons.filter(
+                status__in=[Status.IN_PROGRESS.value, Status.PAUSED.value],
+            ),
+            Status.DROPPED.value,
         )
 
-        for season in in_progress_seasons:
-            season.status = Status.DROPPED.value
+    def _move_seasons_from_status(self, from_status, to_status):
+        """Move seasons that shared the old show status to the new one.
 
-        if in_progress_seasons:
+        Seasons at any other status are left alone, so finished seasons stay
+        finished when a show is paused or moved back to planning.
+        """
+        self._move_seasons(self.seasons.filter(status=from_status), to_status)
+
+    def _move_seasons(self, seasons, to_status):
+        """Set the status of the given seasons.
+
+        Updates bypass ``Season.save`` to avoid cascading straight back into
+        the show.
+        """
+        seasons_to_move = list(seasons)
+
+        for season in seasons_to_move:
+            season.status = to_status
+
+        if seasons_to_move:
             bulk_update_with_history(
-                in_progress_seasons,
+                seasons_to_move,
                 Season,
                 fields=["status"],
             )

--- a/src/app/tests/models/test_tv.py
+++ b/src/app/tests/models/test_tv.py
@@ -431,3 +431,115 @@ class TVStatusTests(TestCase):
 
         season1 = Season.objects.get(pk=self.season1.pk)
         self.assertEqual(season1.status, original_season1_status)
+
+    def _season_statuses(self):
+        """Return the stored status of every season by season number."""
+        return {
+            season.item.season_number: season.status
+            for season in Season.objects.filter(related_tv=self.tv).select_related(
+                "item",
+            )
+        }
+
+    def test_paused_status_cascades_to_seasons_sharing_old_status(self):
+        """Pausing a show pauses only its in-progress seasons (#3)."""
+        # season1 pushed the show to in progress when it was created
+        self.tv.refresh_from_db()
+
+        self.tv.status = Status.PAUSED.value
+        self.tv.save()
+
+        self.assertEqual(
+            self._season_statuses(),
+            {1: Status.PAUSED.value, 2: Status.PLANNING.value},
+        )
+
+    def test_planning_status_cascades_to_seasons_sharing_old_status(self):
+        """Moving a show back to planning follows for its in-progress seasons."""
+        self.tv.refresh_from_db()
+
+        self.tv.status = Status.PLANNING.value
+        self.tv.save()
+
+        self.assertEqual(
+            self._season_statuses(),
+            {1: Status.PLANNING.value, 2: Status.PLANNING.value},
+        )
+
+    def test_paused_status_leaves_completed_seasons_alone(self):
+        """Pausing a show never reopens seasons that are already finished."""
+        Season.objects.filter(pk=self.season2.pk).update(
+            status=Status.COMPLETED.value,
+        )
+        self.tv.refresh_from_db()
+
+        self.tv.status = Status.PAUSED.value
+        self.tv.save()
+
+        self.assertEqual(
+            self._season_statuses(),
+            {1: Status.PAUSED.value, 2: Status.COMPLETED.value},
+        )
+
+    def test_dropped_status_drops_started_seasons(self):
+        """Dropping a show abandons every season underway, paused included."""
+        season3_item = Item.objects.create(
+            media_id="123",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            title="Test Show",
+            image="http://example.com/image.jpg",
+            season_number=3,
+        )
+        Season.save_base(
+            Season(
+                item=season3_item,
+                user=self.user,
+                related_tv=self.tv,
+                status=Status.PAUSED.value,
+            ),
+        )
+        season4_item = Item.objects.create(
+            media_id="123",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            title="Test Show",
+            image="http://example.com/image.jpg",
+            season_number=4,
+        )
+        Season.save_base(
+            Season(
+                item=season4_item,
+                user=self.user,
+                related_tv=self.tv,
+                status=Status.COMPLETED.value,
+            ),
+        )
+        self.tv.refresh_from_db()
+
+        self.tv.status = Status.DROPPED.value
+        self.tv.save()
+
+        self.assertEqual(
+            self._season_statuses(),
+            {
+                1: Status.DROPPED.value,  # was in progress
+                2: Status.PLANNING.value,  # never started
+                3: Status.DROPPED.value,  # was paused
+                4: Status.COMPLETED.value,  # already finished
+            },
+        )
+
+    def test_dropped_to_paused_cascades_to_dropped_seasons(self):
+        """A show leaving dropped takes its dropped seasons with it."""
+        Season.objects.filter(related_tv=self.tv).update(status=Status.DROPPED.value)
+        TV.objects.filter(pk=self.tv.pk).update(status=Status.DROPPED.value)
+        self.tv.refresh_from_db()
+
+        self.tv.status = Status.PAUSED.value
+        self.tv.save()
+
+        self.assertEqual(
+            self._season_statuses(),
+            {1: Status.PAUSED.value, 2: Status.PAUSED.value},
+        )


### PR DESCRIPTION
This PR changes the behavior of how season statuses move when a TV show's status is changed.

Any season with the same status as the show is moved to the new status when a tv show status is changed.

For example:

Tv show: paused
Season 1: completed
Season 2: paused

When the show is changed to in progress, season 2 will also move to in progress.