### PR TITLE
fix: streak shows 0 for unfinished day without plays

### DIFF
--- a/src/app/statistics.py
+++ b/src/app/statistics.py
@@ -669,8 +669,10 @@ def calculate_streaks(date_counts, end_date):
     longest_streak = 1
     streak_count = 1
 
-    # Check if the most recent active date is today/end_date
-    is_current = active_dates[0] == end_date
+    # Today is still in progress, so it doesn't break a streak yet. end_date
+    # comes from the date range picker, so it isn't necessarily today.
+    yesterday = timezone.localdate() - datetime.timedelta(days=1)
+    is_current = active_dates[0] >= min(end_date, yesterday)
 
     current_streak = 1 if is_current else 0
 

--- a/src/app/tests/test_statistics.py
+++ b/src/app/tests/test_statistics.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
+from django.utils import timezone
 
 from app import statistics
 from app.models import (
@@ -955,7 +956,7 @@ class StatisticsTests(TestCase):
             today,
         )
 
-        # No activity today, so current streak is 0
+        # No activity on the last day of the past range, so current streak is 0
         self.assertEqual(current_streak, 0)
         # Longest streak should be 2 (Mar 29-30)
         self.assertEqual(longest_streak, 2)
@@ -968,6 +969,22 @@ class StatisticsTests(TestCase):
         )
         self.assertEqual(current_streak, 0)
         self.assertEqual(longest_streak, 0)
+
+    def test_calculate_streaks_today_in_progress(self):
+        """Test that today without activity yet doesn't break the streak."""
+        today = timezone.localdate()
+        date_counts = {
+            today - datetime.timedelta(days=1): 2,
+            today - datetime.timedelta(days=2): 3,
+        }
+
+        current_streak, longest_streak = statistics.calculate_streaks(
+            date_counts,
+            today,
+        )
+
+        self.assertEqual(current_streak, 2)
+        self.assertEqual(longest_streak, 2)
 
 
 class GetActivityDataWeekStartTests(TestCase):


### PR DESCRIPTION
Currently Yamtrack shows 0 in the statistics when the current day has no history entries. The streak should only show 0 when the previous day has no history.