### PR TITLE
Don't drop show if specials season is dropped

### DIFF
--- a/src/app/models.py
+++ b/src/app/models.py
@@ -1431,6 +1431,7 @@ class Season(Media):
             elif (
                 self.status == Status.DROPPED.value
                 and self.related_tv.status != Status.DROPPED.value
+                and self.item.season_number != 0
             ):
                 self.related_tv.status = Status.DROPPED.value
                 bulk_update_with_history(


### PR DESCRIPTION
When season is marked as `DROPPED` before updating whole show, checks if season was Specials.
If it was Specials season - nothing happens, if it was "normal" season - whole show marked as `DROPPED` as before.
Closes  #1675