### PR TITLE
Fix episode scheduling: next-episode ties, TVMaze/TMDB numbering and date mismatches

### DIFF
--- a/src/app/models.py
+++ b/src/app/models.py
@@ -483,7 +483,7 @@ class MediaManager(models.Manager):
                     for event in getattr(media.item, "prefetched_events", [])
                     if event.datetime > current_time
                 ],
-                key=lambda e: e.datetime,
+                key=lambda e: (e.datetime, e.content_number or 0),
             )
 
             media.next_event = future_events[0] if future_events else None

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -476,14 +476,27 @@ class MediaManager(models.Manager):
         current_time = timezone.now()
 
         for media in media_list:
-            # Get future events sorted by datetime
+            # Get future events for this item and pick the lowest-numbered
+            # one. `datetime` only decides whether an event has aired yet;
+            # ordering by it as well is unreliable because a provider's
+            # reported time-of-day for same-day releases can be wrong or
+            # inconsistent even when the date itself is correct (unlike the
+            # date, which #1182/#1699 already cross-check against TMDB), so
+            # two same-day episodes can end up with datetimes that put the
+            # later episode number first. content_number is unique per item
+            # and reflects the actual release order, so it is the
+            # authoritative tiebreaker - and primary key - here.
             future_events = sorted(
                 [
                     event
                     for event in getattr(media.item, "prefetched_events", [])
                     if event.datetime > current_time
                 ],
-                key=lambda e: (e.datetime, e.content_number or 0),
+                key=lambda e: (
+                    e.content_number is None,
+                    e.content_number or 0,
+                    e.datetime,
+                ),
             )
 
             media.next_event = future_events[0] if future_events else None

--- a/src/app/tests/models/test_media_manager.py
+++ b/src/app/tests/models/test_media_manager.py
@@ -776,6 +776,52 @@ class MediaManagerTests(TestCase):
         self.assertIsNotNone(anime_list[0].next_event)
         self.assertEqual(anime_list[0].next_event.content_number, 1)
 
+    def test_annotate_next_event_picks_lowest_number_when_times_disagree(self):
+        """Next event should pick the lowest number even when times disagree.
+
+        Regression test for a report where TVMaze/TMDB agreed on the same
+        release *date* for two episodes (so the exact-tie case above didn't
+        apply), but the stored time-of-day for episode 2 was earlier than
+        episode 1's, making episode 2 sort first if datetime were the
+        primary ordering key. content_number is unique per item and defines
+        the true release order, so it must win over datetime for ordering
+        (datetime should only gate whether an event has aired yet).
+        """
+        manager = MediaManager()
+
+        release_day = (timezone.now() + timedelta(days=1)).replace(
+            hour=0,
+            minute=0,
+            second=0,
+            microsecond=0,
+        )
+
+        # Episode 2's stored time-of-day is earlier than episode 1's, even
+        # though both are meant to release on the same day.
+        Event.objects.create(
+            item=self.anime_item,
+            content_number=2,
+            datetime=release_day,
+        )
+        Event.objects.create(
+            item=self.anime_item,
+            content_number=1,
+            datetime=release_day + timedelta(hours=12),
+        )
+
+        queryset = Anime.objects.filter(user=self.user.id).select_related("item")
+        anime_list = list(queryset)
+
+        for anime in anime_list:
+            anime.item.prefetched_events = list(
+                Event.objects.filter(item=anime.item).order_by("-datetime"),
+            )
+
+        manager._annotate_next_event(anime_list)
+
+        self.assertIsNotNone(anime_list[0].next_event)
+        self.assertEqual(anime_list[0].next_event.content_number, 1)
+
     def test_sort_home_media(self):
         """Test the _sort_home_media method."""
         manager = MediaManager()

--- a/src/app/tests/models/test_media_manager.py
+++ b/src/app/tests/models/test_media_manager.py
@@ -736,6 +736,46 @@ class MediaManagerTests(TestCase):
 
         self.assertIsNone(anime_list[0].next_event)
 
+    def test_annotate_next_event_multiple_episodes_same_datetime(self):
+        """Next event should pick the lowest episode number when air dates tie.
+
+        Regression test for https://github.com/FuzzyGrim/Yamtrack/issues/1655
+        where a season with multiple episodes released on the same day could
+        show episode 2 (or later) as the "next episode" instead of episode 1.
+        """
+        manager = MediaManager()
+
+        same_datetime = timezone.now() + timedelta(days=1)
+
+        # Create events out of episode-number order so that relying on
+        # insertion/query order alone would surface the wrong episode.
+        Event.objects.create(
+            item=self.anime_item,
+            content_number=2,
+            datetime=same_datetime,
+        )
+        Event.objects.create(
+            item=self.anime_item,
+            content_number=1,
+            datetime=same_datetime,
+        )
+
+        queryset = Anime.objects.filter(user=self.user.id).select_related("item")
+        anime_list = list(queryset)
+
+        for anime in anime_list:
+            # Simulate the DB returning the tied events in descending-datetime
+            # order (Event.Meta.ordering) with no secondary ordering, so ties
+            # come back in an arbitrary/insertion order.
+            anime.item.prefetched_events = list(
+                Event.objects.filter(item=anime.item).order_by("-datetime"),
+            )
+
+        manager._annotate_next_event(anime_list)
+
+        self.assertIsNotNone(anime_list[0].next_event)
+        self.assertEqual(anime_list[0].next_event.content_number, 1)
+
     def test_sort_home_media(self):
         """Test the _sort_home_media method."""
         manager = MediaManager()

--- a/src/events/calendar/tv.py
+++ b/src/events/calendar/tv.py
@@ -322,7 +322,28 @@ def get_episode_datetime(episode, season_number, episode_number, tvmaze_map):
     tvmaze_airstamp = tvmaze_map.get(tvmaze_key)
 
     if tvmaze_airstamp:
-        return datetime.fromisoformat(tvmaze_airstamp)
+        tvmaze_datetime = datetime.fromisoformat(tvmaze_airstamp)
+        tmdb_air_date = episode.get("air_date")
+
+        if not tmdb_air_date or tvmaze_date_matches_tmdb(
+            tvmaze_datetime,
+            tmdb_air_date,
+        ):
+            return tvmaze_datetime
+
+        # TVMaze occasionally has outright wrong air dates for a show even
+        # though its episode count matches TMDB's (unlike the numbering
+        # shift in issue #1182). When the two sources disagree on the date
+        # for the same episode, prefer TMDB's, which is corroborated by
+        # TheTVDB in these cases.
+        logger.warning(
+            "S%sE%s - TVMaze air date (%s) disagrees with TMDB (%s), "
+            "falling back to TMDB",
+            season_number,
+            episode_number,
+            tvmaze_datetime.date(),
+            tmdb_air_date,
+        )
 
     if episode["air_date"]:
         try:
@@ -336,6 +357,22 @@ def get_episode_datetime(episode, season_number, episode_number, tvmaze_map):
             )
 
     return None
+
+
+def tvmaze_date_matches_tmdb(tvmaze_datetime, tmdb_air_date):
+    """Check whether TVMaze's air date (in its own timezone) matches TMDB's.
+
+    ``tvmaze_datetime`` carries the broadcast region's own UTC offset, so its
+    date component is compared directly against TMDB's date rather than
+    converting to UTC first, which would spuriously shift the date for
+    broadcasts near midnight.
+    """
+    try:
+        tmdb_datetime = date_parser(tmdb_air_date)
+    except ValueError:
+        return True
+
+    return tvmaze_datetime.date() == tmdb_datetime.date()
 
 
 def tvmaze_season_episode_count_matches(tvmaze_map, season_number, tmdb_episode_count):

--- a/src/events/calendar/tv.py
+++ b/src/events/calendar/tv.py
@@ -273,6 +273,25 @@ def process_season_episodes(item, metadata, events_bulk):
         return
 
     season_number = metadata["season_number"]
+
+    if tvmaze_map and not tvmaze_season_episode_count_matches(
+        tvmaze_map,
+        season_number,
+        len(metadata["episodes"]),
+    ):
+        # TVMaze sometimes splits or merges episodes differently than TMDB
+        # (e.g. one TMDB episode airing as two on TVMaze), which shifts every
+        # subsequent TVMaze episode number - and its air date - by one
+        # relative to TMDB (see issue #1182). Only trust TVMaze's per-episode
+        # dates for a season when both sources agree on the episode count.
+        logger.warning(
+            "%s - TVMaze episode count for season %s does not match TMDB, "
+            "falling back to TMDB air dates for this season",
+            item,
+            season_number,
+        )
+        tvmaze_map = {}
+
     episode_datetimes = {
         episode["episode_number"]: get_episode_datetime(
             episode,
@@ -317,6 +336,13 @@ def get_episode_datetime(episode, season_number, episode_number, tvmaze_map):
             )
 
     return None
+
+
+def tvmaze_season_episode_count_matches(tvmaze_map, season_number, tmdb_episode_count):
+    """Check whether TVMaze's episode count for a season matches TMDB's."""
+    season_prefix = f"{season_number}_"
+    tvmaze_episode_count = sum(1 for key in tvmaze_map if key.startswith(season_prefix))
+    return tvmaze_episode_count == tmdb_episode_count
 
 
 def get_tvmaze_episode_map(tvdb_id):

--- a/src/events/tests/calendar/test_tv.py
+++ b/src/events/tests/calendar/test_tv.py
@@ -270,6 +270,83 @@ class CalendarTVTests(CalendarFixturesMixin, TestCase):
 
         self.assertEqual(result, date_parser("2025-01-31"))
 
+    def test_get_episode_datetime_uses_tvmaze_when_dates_agree(self):
+        """TVMaze's timestamp should be used when its date matches TMDB's."""
+        result = get_episode_datetime(
+            {"air_date": "2008-01-20"},
+            season_number=1,
+            episode_number=1,
+            tvmaze_map={"1_1": "2008-01-20T22:00:00+00:00"},
+        )
+
+        self.assertEqual(
+            result,
+            datetime.datetime.fromisoformat("2008-01-20T22:00:00+00:00"),
+        )
+
+    def test_get_episode_datetime_falls_back_when_tvmaze_date_wrong(self):
+        """TMDB's date should win when TVMaze's date outright disagrees.
+
+        Regression test for a report where TVMaze had the correct episode
+        count for a season but flat-out wrong air dates (three episodes
+        bunched on one date, three on another) while TMDB, TheTVDB, and IMDB
+        all agreed on a weekly schedule.
+        """
+        result = get_episode_datetime(
+            {"air_date": "2026-08-27"},
+            season_number=2,
+            episode_number=2,
+            tvmaze_map={"2_2": "2026-08-20T20:00:00+01:00"},
+        )
+
+        self.assertEqual(result, date_parser("2026-08-27"))
+
+    @patch("events.calendar.tv.get_tvmaze_episode_map")
+    def test_process_season_episodes_falls_back_when_tvmaze_dates_wrong(
+        self,
+        mock_get_tvmaze_episode_map,
+    ):
+        """A season where TVMaze's dates disagree with TMDB's should use TMDB.
+
+        Same episode count on both sides, but TVMaze bunches three episodes
+        on one date and three on another instead of the correct weekly
+        cadence that TMDB (and TheTVDB) report.
+        """
+        mock_get_tvmaze_episode_map.return_value = {
+            "2_1": "2026-08-13T20:00:00+01:00",
+            "2_2": "2026-08-13T20:00:00+01:00",
+            "2_3": "2026-08-13T20:00:00+01:00",
+            "2_4": "2026-12-25T20:00:00+01:00",
+            "2_5": "2026-12-25T20:00:00+01:00",
+            "2_6": "2026-12-25T20:00:00+01:00",
+        }
+
+        events_bulk = []
+        process_season_episodes(
+            self.season_item,
+            {
+                "season_number": 2,
+                "tvdb_id": "81189",
+                "episodes": [
+                    {"episode_number": 1, "air_date": "2026-08-20"},
+                    {"episode_number": 2, "air_date": "2026-08-27"},
+                    {"episode_number": 3, "air_date": "2026-09-03"},
+                    {"episode_number": 4, "air_date": "2026-09-10"},
+                    {"episode_number": 5, "air_date": "2026-09-17"},
+                    {"episode_number": 6, "air_date": "2026-09-24"},
+                ],
+            },
+            events_bulk,
+        )
+
+        by_number = {event.content_number: event for event in events_bulk}
+        self.assertEqual(by_number[1].datetime, date_parser("2026-08-20"))
+        self.assertEqual(by_number[2].datetime, date_parser("2026-08-27"))
+        self.assertEqual(by_number[3].datetime, date_parser("2026-09-03"))
+        self.assertEqual(by_number[4].datetime, date_parser("2026-09-10"))
+        self.assertEqual(by_number[5].datetime, date_parser("2026-09-17"))
+        self.assertEqual(by_number[6].datetime, date_parser("2026-09-24"))
+
     @patch("events.calendar.tv.get_tvmaze_episode_map")
     def test_process_season_episodes_falls_back_when_tvmaze_count_mismatches(
         self,

--- a/src/events/tests/calendar/test_tv.py
+++ b/src/events/tests/calendar/test_tv.py
@@ -270,6 +270,48 @@ class CalendarTVTests(CalendarFixturesMixin, TestCase):
 
         self.assertEqual(result, date_parser("2025-01-31"))
 
+    @patch("events.calendar.tv.get_tvmaze_episode_map")
+    def test_process_season_episodes_falls_back_when_tvmaze_count_mismatches(
+        self,
+        mock_get_tvmaze_episode_map,
+    ):
+        """A TVMaze/TMDB episode-count mismatch should discard TVMaze dates.
+
+        Regression test for https://github.com/FuzzyGrim/Yamtrack/issues/1182
+        where TVMaze splits one TMDB episode into two, shifting every later
+        TVMaze episode number - and its air date - by one relative to TMDB.
+        Trusting the shifted dates makes not-yet-aired episodes look released.
+        """
+        # TVMaze has an extra episode (a split) that TMDB does not have, so
+        # TVMaze's "2" is really TMDB's episode 1's second half, and every
+        # later TVMaze number is shifted by one.
+        mock_get_tvmaze_episode_map.return_value = {
+            "1_1": "2008-01-20T22:00:00+00:00",
+            "1_2": "2008-01-20T22:30:00+00:00",
+            "1_3": "2008-01-27T22:00:00+00:00",
+            "1_4": "2008-02-03T22:00:00+00:00",
+        }
+
+        events_bulk = []
+        process_season_episodes(
+            self.season_item,
+            {
+                "season_number": 1,
+                "tvdb_id": "81189",
+                "episodes": [
+                    {"episode_number": 1, "air_date": "2008-01-20"},
+                    {"episode_number": 2, "air_date": "2008-01-27"},
+                    {"episode_number": 3, "air_date": "2008-02-03"},
+                ],
+            },
+            events_bulk,
+        )
+
+        by_number = {event.content_number: event for event in events_bulk}
+        self.assertEqual(by_number[1].datetime, date_parser("2008-01-20"))
+        self.assertEqual(by_number[2].datetime, date_parser("2008-01-27"))
+        self.assertEqual(by_number[3].datetime, date_parser("2008-02-03"))
+
     def test_get_episode_datetime_returns_none_for_invalid_date(self):
         """Invalid or missing episode dates should resolve to None (unknown)."""
         result = get_episode_datetime(


### PR DESCRIPTION
## Summary

Four related bugs in episode-date/next-episode handling, each with its own commit and regression test:

- **#1655** — On the home page, when a season releases multiple episodes on the same air date, the "next episode" badge could show a later episode (e.g. E2) instead of E1. `Event.Meta.ordering` only sorts by `datetime`, so the tie between same-day events was broken arbitrarily by query order. First fixed by sorting by `(datetime, content_number)`, but a follow-up report ("Neuromancer" S1: E1 and E2 both release the same day, yet the stored times-of-day for the two episodes disagreed, e.g. from a provider only partially covering a season far in advance) showed that same-day events don't always end up with identical datetimes. Since `content_number` is unique per item and defines the true release order, `datetime` is now used only to gate whether an event has aired, with `content_number` as the primary ordering key.
- **#1182** — TVMaze sometimes splits/merges an episode differently than TMDB, shifting every later TVMaze episode number (and its date) by one relative to TMDB. Since Yamtrack matches TVMaze dates to TMDB episodes purely by number, this could make a not-yet-aired episode look released. Fixed by checking that TVMaze and TMDB agree on the season's episode count before trusting TVMaze's per-episode dates; falls back to TMDB for the whole season otherwise.
- **#1699** (new issue, filed as part of this PR) — TVMaze can have an outright wrong air date for an episode even when its episode count matches TMDB's (e.g. "Ludwig" S2: TVMaze bunched all 6 episodes onto two dates while TMDB/TheTVDB reported the correct weekly schedule). Fixed by comparing TVMaze's date (in its own broadcast-region offset) against TMDB's per episode, and preferring TMDB's when they disagree.

## AI disclosure

These fixes, including the regression tests and this description, were drafted with [Claude Code](https://claude.com/claude-code) (Anthropic) working from the linked bug reports, then reviewed before opening/updating this PR.

## Test plan

- [x] `pytest src/app/tests/models/test_media_manager.py` — 19 passed
- [x] `pytest src/events/` — 125 passed
- [x] Added regression tests for each fix; verified each fails on the pre-fix code and passes with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)