### PR TITLE
Fix: keep planning seasons visible when some episodes have aired

### DIFF
--- a/src/app/home.py
+++ b/src/app/home.py
@@ -1,6 +1,6 @@
 from django.utils.text import slugify
 
-from app.models import BasicMedia, Status
+from app.models import BasicMedia, MediaTypes, Status
 
 
 def build_home_section(key, media_types):
@@ -90,4 +90,13 @@ def _is_released_home_media(media, section_key):
     if section_key == Status.IN_PROGRESS.value:
         return is_active_in_progress_media(media)
 
-    return not _is_incoming_media(media)
+    # Movies release atomically, so max_progress is a static completion
+    # flag rather than a released-content count - an upcoming next_event
+    # always means nothing is available yet.
+    if media.item.media_type == MediaTypes.MOVIE.value:
+        return not _is_incoming_media(media)
+
+    # Other media types (e.g. TV seasons) can have some content already
+    # released even while future episodes are still upcoming, so fall
+    # back to comparing against progress rather than hiding outright.
+    return is_active_in_progress_media(media)

--- a/src/app/tests/views/test_home.py
+++ b/src/app/tests/views/test_home.py
@@ -305,6 +305,45 @@ class HomeViewTests(TestCase):
             any(media.item.media_id == "planning-with-release" for media in movies),
         )
 
+    def test_home_view_keeps_planning_season_with_partial_release(self):
+        """Planning season with some episodes already out stays when filtered."""
+        partial_item = Item.objects.create(
+            media_id="planning-partial-release",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            title="Partially Released Show",
+            image="http://example.com/image.jpg",
+            season_number=1,
+        )
+        Season.objects.create(
+            item=partial_item,
+            user=self.user,
+            status=Status.PLANNING.value,
+        )
+        Event.objects.create(
+            item=partial_item,
+            content_number=1,
+            datetime=timezone.now() - timezone.timedelta(days=1),
+        )
+        Event.objects.create(
+            item=partial_item,
+            content_number=2,
+            datetime=timezone.now() + timezone.timedelta(days=1),
+        )
+
+        response = self.client.get(reverse("home") + "?hide_unreleased=true")
+
+        self.assertEqual(response.status_code, 200)
+        planning_section = next(
+            section
+            for section in response.context["home_sections"]
+            if section["key"] == Status.PLANNING.value
+        )
+        seasons = planning_section["media_types"][MediaTypes.SEASON.value]["items"]
+        self.assertTrue(
+            any(media.item.media_id == "planning-partial-release" for media in seasons),
+        )
+
     def test_home_view_htmx_load_more_preserves_hide_unreleased(self):
         """Test HTMX load more applies hide unreleased filter."""
         self.user.home_hide_unreleased = True


### PR DESCRIPTION
## Summary
- The "Hide unreleased" filter added in #1371 only checked whether a season had a real *upcoming* next episode, so a Planning-status season with a mix of released and unreleased episodes was hidden entirely, even though earlier episodes were already available to watch.
- Planning-section items now reuse the same released-backlog check already used for the In Progress section (`is_active_in_progress_media`): keep the item if there's no real upcoming event, or if the released-content count exceeds current progress.
- Movies keep the old simple check, since a movie's `max_progress` is a static completion flag rather than an actual released-episode count, so applying the backlog check to them would incorrectly reveal not-yet-released movies.

## Test plan
- [x] Added `test_home_view_keeps_planning_season_with_partial_release` covering a Planning season with one released and one upcoming episode, verifying it stays visible when "Hide unreleased" is enabled.
- [x] `python manage.py test app.tests.views.test_home` — all pass.
- [x] `python manage.py test app.tests.views.test_progress app.tests` — full app suite passes (one pre-existing, unrelated failure in `test_hardcover_book` against live provider metadata).

🤖 Generated with [Claude Code](https://claude.com/claude-code)